### PR TITLE
Better node cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keeping a ros1::ServiceServer alive no longer keeps the underlying node alive past the last ros1::NodeHandle being dropped.
+- Dropping the last ros1::NodeHandle results in the node cleaning up any advertises, subscriptions, and services with the ROS master.
+
 ### Changed
 
 ## 0.11.1

--- a/roslibrust/src/ros1/master_client.rs
+++ b/roslibrust/src/ros1/master_client.rs
@@ -20,6 +20,7 @@ pub enum RosMasterError {
 
 /// A client that exposes the API hosted by the [rosmaster](http://wiki.ros.org/ROS/Master_API)
 // TODO consider exposing this type publicly
+#[derive(Clone)] // Note is clone to support an odd case in Node::drop
 pub struct MasterClient {
     client: reqwest::Client,
     // Address at which the rosmaster should be found

--- a/roslibrust/src/ros1/node/actor.rs
+++ b/roslibrust/src/ros1/node/actor.rs
@@ -39,6 +39,9 @@ pub enum NodeMsg {
         topic: String,
         publishers: Vec<String>,
     },
+    // This function exists because "shutdown" is one of the XmlRpc Client APIs that is
+    // technically part of the ROS ecosystem (never really seen it used)
+    // This results in the node's task ending and the node being dropped.
     Shutdown,
     RegisterPublisher {
         reply: oneshot::Sender<Result<mpsc::Sender<Vec<u8>>, String>>,
@@ -87,6 +90,11 @@ pub enum NodeMsg {
     },
 }
 
+/// Represents a communication handle to an underlying node server
+/// The node server handles all communication with ROS Master and keeps
+/// track of subscriptions, publishers, etc.
+/// Things that need to interact with the node server do so through a command channel
+/// Some handles are "root" handles that when dropped also drop the node server.
 #[derive(Clone)]
 pub(crate) struct NodeServerHandle {
     pub(crate) node_server_sender: mpsc::UnboundedSender<NodeMsg>,
@@ -146,7 +154,6 @@ impl NodeServerHandle {
     /// Informs the underlying node server to shutdown
     /// This will stop all ROS functionality and poison all NodeHandles connected
     /// to the underlying node server.
-    // TODO this function should probably be pub(crate) and not pub?
     pub(crate) fn shutdown(&self) -> Result<(), NodeError> {
         self.node_server_sender.send(NodeMsg::Shutdown)?;
         Ok(())
@@ -373,6 +380,8 @@ impl NodeServerHandle {
     }
 }
 
+// TODO we sometimes refer to this entity as "Node" and sometimes as "NodeServer"
+// we should standardize terminology.
 /// Represents a single "real" node, typically only one of these is expected per process
 /// but nothing should specifically prevent that.
 /// This is sometimes referred to as the NodeServer in the documentation, many NodeHandles can point to one NodeServer
@@ -452,6 +461,8 @@ impl Node {
                             node.handle_msg(node_msg).await;
                         }
                         None => {
+                            // This isn't an really expected case?
+                            log::warn!("Node command channel closed, shutting down");
                             break;
                         }
                     }
@@ -841,5 +852,52 @@ impl Node {
                 "Attempt to unregister service that is not currently registered",
             )));
         }
+    }
+
+    // Clears any extant node connections with the ros master
+    // This is not expected to be called anywhere other than the drop impl
+    fn shutdown(&mut self) {
+        let future = async {
+            // Note: we're ignoring all failures here and doing best effort cleanup
+            // Many of these log messages will be incorrect until we get our cleanup logic dialed in.
+            for (topic, _subscriptions) in &self.subscriptions {
+                debug!("Node shutdown is cleaning up subscription: {topic}");
+                let _ = self.client.unregister_subscriber(topic).await.map_err(|e| {
+                    error!("Failed to unregister subscriber for topic: {topic} while shutting down node");
+                    e
+                });
+                debug!("CHECK");
+            }
+
+            for (topic, _publication) in &self.publishers {
+                debug!("Node shutdown is cleaning up publishing: {topic}");
+                let _ = self.client.unregister_publisher(topic).await.map_err(|e| {
+                    error!("Failed to unregister publisher for topic: {topic} while shutting down node.");
+                    e
+                });
+            }
+
+            for (topic, service_link) in &self.service_servers {
+                debug!("Node shutdown is cleaning up service: {topic}");
+                let uri = format!("rosrpc://{}:{}", self.host_addr, service_link.port());
+                let _ = self.client.unregister_service(topic, uri).await.map_err(|e| {
+                    error!("Failed to unregister server server for topic: {topic} while shutting down node.");
+                    e
+                });
+            }
+        };
+
+        let runtime = tokio::runtime::Handle::try_current().expect("Roslibrust should always be run inside tokio runtime");
+        // Run the shutdown tasks to completion
+        runtime.block_on(future);
+    }
+}
+
+// It is important to clean-up any stray topic / service connections when we shut down
+// Goal of this implementation is that the node appears fully dead to ROS after this and
+// `rosnode list` / `rosnode info` don't show any remaining connections.
+impl Drop for Node {
+    fn drop(&mut self) {
+        self.shutdown();
     }
 }

--- a/roslibrust/src/ros1/node/handle.rs
+++ b/roslibrust/src/ros1/node/handle.rs
@@ -9,6 +9,7 @@ use crate::{
 
 /// Represents a handle to an underlying Node. NodeHandle's can be freely cloned, moved, copied, etc.
 /// This class provides the user facing API for interacting with ROS.
+/// The last node handle dropped shuts down the node.
 #[derive(Clone)]
 pub struct NodeHandle {
     inner: NodeServerHandle,

--- a/roslibrust/src/ros1/publisher.rs
+++ b/roslibrust/src/ros1/publisher.rs
@@ -240,7 +240,9 @@ impl Publication {
                     // Tell the node server to dispose of this publication and unadvertise it
                     // Note: we need to do this in a spawned task or a drop-loop race condition will occur
                     // Dropping publication results in this task being dropped, which can end up canceling the future that is doing the dropping
-                    // if we simpply .await here
+                    // if we simply .await here
+                    // TODO: This allows publisher to clean themselves up iff node remains running after publisher is dropped...
+                    // NodeHandle clean-up is not resulting in a good state clean-up currently..
                     let nh_copy = node_handle.clone();
                     let topic = topic.clone();
                     tokio::spawn(async move {

--- a/roslibrust/tests/ros1_native_integration_tests.rs
+++ b/roslibrust/tests/ros1_native_integration_tests.rs
@@ -465,4 +465,65 @@ mod tests {
             "std_msgs/Header".to_string()
         )));
     }
+
+    /// Test that we correctly purge references to publishers, subscribers and services servers when a node shuts down
+    #[test_log::test(tokio::test)]
+    async fn node_cleanup() {
+        let future = async {
+            // Create our node
+            // this nh controls the lifetimes
+            let nh = NodeHandle::new("http://localhost:11311", "/test_node_cleanup")
+                .await
+                .unwrap();
+
+            // Create a publisher so a topic will connected
+            let _publisher = nh
+                .advertise::<std_msgs::Header>("/test_cleanup_pub", 1, false)
+                .await
+                .unwrap();
+
+            let _subscriber = nh
+                .subscribe::<std_msgs::Header>("/test_cleanup_sub", 1)
+                .await
+                .unwrap();
+
+            let _service_server = nh
+                .advertise_service::<std_srvs::Trigger, _>("/test_cleanup_srv", |_req| {
+                    Ok(Default::default())
+                })
+                .await
+                .unwrap();
+
+            let master_client = roslibrust::ros1::MasterClient::new(
+                "http://localhost:11311",
+                "NAN",
+                "/test_node_cleanup_checker",
+            )
+            .await
+            .unwrap();
+
+            let data = master_client.get_system_state().await.unwrap();
+            info!("Got data before drop: {data:?}");
+
+            // Check that our three connections are reported by the ros master before starting
+            assert!(data.is_publishing("/test_cleanup_pub", "/test_node_cleanup"));
+            assert!(data.is_subscribed("/test_cleanup_sub", "/test_node_cleanup"));
+            assert!(data.is_service_provider("/test_cleanup_srv", "/test_node_cleanup"));
+
+            // Drop our node handle
+            std::mem::drop(nh);
+
+            // Delay to allow destructor to complete
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            let data = master_client.get_system_state().await.unwrap();
+            info!("Got data after drop: {data:?}");
+
+            // Check that our three connections are no longer reported by the ros master after dropping
+            assert!(!data.is_publishing("/test_cleanup_pub", "/test_node_cleanup"));
+            assert!(!data.is_subscribed("/test_cleanup_sub", "/test_node_cleanup"));
+            assert!(!data.is_service_provider("/test_cleanup_srv", "/test_node_cleanup"));
+        };
+        // 1 second to complete the whole test.
+        tokio::time::timeout(tokio::time::Duration::from_secs(1), future).await.unwrap();
+    }
 }

--- a/roslibrust/tests/ros1_native_integration_tests.rs
+++ b/roslibrust/tests/ros1_native_integration_tests.rs
@@ -525,5 +525,4 @@ mod tests {
         assert!(!data.is_subscribed("/test_cleanup_sub", "/test_node_cleanup"));
         assert!(!data.is_service_provider("/test_cleanup_srv", "/test_node_cleanup"));
     }
-
 }


### PR DESCRIPTION
## Description
ROS1 Node Clears any and all Advertises, Subscribes, and Services with the ROS master when dropped. Goal here is that we don't leave junk in `rosnode list` / `rosnode info` after our node shuts down.

I don't love this design and it should be redundant if Publishers / Subscriptions and Service Servers cleanup after themselves correctly, but there is some good redundancy in doing this.

## Fixes
Closes: `number`

## Checklist
- [ ] Update CHANGELOG.md

