### PR TITLE
Update roslibrust_serde_rosmsg to improve serialization speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- roslibrust_serde_rosmsg verison updated resulting in a significant performance boost on serializing large messages. 95% gains measured on 1080p color image serialization. 25% gains measured on roundtrip image benchmarks with ros1 backend.
+
 ### Changed
 
 ## 0.12.0 - January 7th, 2025

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "roslibrust_serde_rosmsg"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcb4a6411b4969947dd4fcc23488c4fd7e2e3c180c8d167bece0661df5c0fae"
+checksum = "8ce8ff385202b488c2cb350e7fe6601264c78e63f28fb0b3488dee822a1d8616"
 dependencies = [
  "byteorder",
  "error-chain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ tokio = {version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 # Someday we may move this crate into this workspace
 # For now this is how we keep from repeating the verison everywhere
-roslibrust_serde_rosmsg = "0.4"
+roslibrust_serde_rosmsg = "0.5.0"

--- a/roslibrust_ros1/Cargo.toml
+++ b/roslibrust_ros1/Cargo.toml
@@ -25,7 +25,7 @@ test-log = "0.2"
 # These are definitely needed by this crate:
 reqwest = { version = "0.11" }
 serde_xmlrpc = { version = "0.2" }
-roslibrust_serde_rosmsg = { version = "0.4" }
+roslibrust_serde_rosmsg = { workspace = true }
 hyper = { version = "0.14", features = ["server"] }
 gethostname = { version = "0.4" }
 regex = { version = "1.9" }

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -14,7 +14,6 @@ log = { workspace = true }
 diffy = "0.3.0"
 criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
 pprof = { version = "0.11", features = ["flamegraph", "criterion"] }
-tokio = { workspace = true }
 
 [[bin]]
 path = "src/performance_ramp.rs"


### PR DESCRIPTION
25% gain in image_bench:

```
     Running benches/image_bench.rs (/home/carter/open_source/roslibrust/target/release/deps/image_bench-53c844cf7ef286e4)
Gnuplot not found, using plotters backend
image_bench             time:   [16.460 ms 16.821 ms 17.188 ms]
                        change: [-28.889% -26.797% -24.635%] (p = 0.00 < 0.05)
                        Performance has improved.
```
![image](https://github.com/user-attachments/assets/6989f3ac-190e-4588-a6e8-481d87be950e)


## Description
`Insert description`

## Fixes
Closes: `number`

## Checklist
- [x] Update CHANGELOG.md

