### PR TITLE
Async Service Examples and Backend Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Examples and documentation for performing `async` actions in service callbacks.
+
 ### Fixed
 
 ### Changed
+
+- All user provided service server functions are now executed inside of a `tokio::task::spawn_blocking` call, and blocking withing the service function is now safe.
 
 ## 0.13.0 - March 27th, 2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "log",
  "pprof",
  "roslibrust",
+ "test-log",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1.0", features = ["derive"] }
 # Someday we may move this crate into this workspace
 # For now this is how we keep from repeating the verison everywhere
 roslibrust_serde_rosmsg = "0.5.0"
+test-log = "0.2"

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -21,7 +21,7 @@ roslibrust_codegen_macro = { path = "../roslibrust_codegen_macro", version = "0.
 
 [dev-dependencies]
 env_logger = "0.11"
-test-log = "0.2"
+test-log = { workspace = true }
 abort-on-drop = "0.2"
 log = { workspace = true }
 tokio = { workspace = true }

--- a/roslibrust/examples/ros1_async_service_server.rs
+++ b/roslibrust/examples/ros1_async_service_server.rs
@@ -1,0 +1,86 @@
+#[cfg(feature = "ros1")]
+roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_interfaces");
+
+/// This example shows how to perform async actions correctly in a service callback.
+///
+/// This is the recommended way to do async actions in a service callback for the time being.
+/// We hope to improve this API in the future with `async closures`.
+
+#[cfg(feature = "ros1")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use log::*;
+    use roslibrust::ros1::NodeHandle;
+
+    // Create a logger to help make this example easier to debug
+    env_logger::init();
+
+    // Create a ros1 node and connect to a ros master
+    let nh = NodeHandle::new("http://localhost:11311", "service_server_rs").await?;
+    log::info!("Connected!");
+
+    // Create an async channel to represent something like another service that a service would like to call
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+    let server_fn = move |request: std_srvs::SetBoolRequest| {
+        log::info!("Got request to set bool: {request:?}");
+
+        // We need an access to the tokio runtime to perform async actions.
+        // Luckily, tokio provides a method to get the current runtime handle.
+        let handle = tokio::runtime::Handle::current();
+
+        // This handle then lets us use the `block_on` method to run an async block.
+        // Note: the async block and future it generates only borrow tx!
+        // If you need ownership of your async handles you need to .clone() them and use `async move {}`
+        handle.block_on(async {
+            // In here we can now perform async actions, like pushing our request into the channel
+            let _ = tx.send(request.data).await;
+        });
+
+        Ok(std_srvs::SetBoolResponse {
+            success: true,
+            message: "You set my bool!".to_string(),
+        })
+    };
+
+    // Start our service running!
+    let _handle = nh
+        .advertise_service::<std_srvs::SetBool, _>("~/my_set_bool", server_fn)
+        .await?;
+    info!("Service has started");
+
+    // Setup a task to kill this process when ctrl_c comes in:
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.unwrap();
+        std::process::exit(0);
+    });
+
+    // As long as _handle is kept alive our service will continue to run
+
+    // For fun, we can also spawn a task to periodically call our service
+    let service_client = nh
+        .service_client::<std_srvs::SetBool>("~/my_set_bool")
+        .await?;
+    tokio::spawn(async move {
+        let mut bool = false;
+        loop {
+            bool = !bool;
+            service_client
+                .call(&std_srvs::SetBoolRequest { data: bool })
+                .await
+                .unwrap();
+            tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        }
+    });
+
+    // We can also await getting values from our channel
+    loop {
+        let cur_bool = rx.recv().await.unwrap();
+        info!("Current value of our bool out of channel: {cur_bool}");
+    }
+}
+
+#[cfg(not(feature = "ros1"))]
+fn main() {
+    eprintln!("This example does nothing without compiling with the feature 'ros1'");
+}

--- a/roslibrust_codegen/Cargo.toml
+++ b/roslibrust_codegen/Cargo.toml
@@ -35,7 +35,7 @@ serde_bytes = "0.11"
 
 [dev-dependencies]
 env_logger = "0.10"
-test-log = "0.2"
+test-log = { workspace = true }
 
 [features]
 default = ["tokio"]

--- a/roslibrust_common/src/traits.rs
+++ b/roslibrust_common/src/traits.rs
@@ -80,7 +80,10 @@ pub trait ServiceProvider {
     /// A handle is returned that manages the lifetime of the service.
     /// Dropping the handle will perform all needed cleanup.
     /// The service will be active until the handle is dropped.
-    /// Currently this function only accepts non-async functions, but with the stabilization of async closures this may change.
+    /// The service will always be called inside a [tokio::task::spawn_blocking] call.
+    /// It is generally okay to perform blocking actions inside the service function.
+    ///  - See [roslibrust/examples/ros1_service_server.rs](https://github.com/RosLibRust/roslibrust/blob/master/roslibrust/examples/ros1_service_server.rs) for a sync example of using this function.
+    ///  - See [roslibrust/examples/ros1_async_service_server.rs](https://github.com/RosLibRust/roslibrust/blob/master/roslibrust/examples/ros1_async_service_server.rs) for an async example of using this function.
     fn advertise_service<T: RosServiceType + 'static, F>(
         &self,
         topic: &str,

--- a/roslibrust_ros1/Cargo.toml
+++ b/roslibrust_ros1/Cargo.toml
@@ -20,7 +20,7 @@ serde = { workspace = true }
 # Should probably become workspace members:
 lazy_static = "1.4"
 abort-on-drop = "0.2"
-test-log = "0.2"
+test-log = { workspace = true }
 
 # These are definitely needed by this crate:
 reqwest = { version = "0.11" }

--- a/roslibrust_ros1/src/main.rs
+++ b/roslibrust_ros1/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/roslibrust_rosapi/Cargo.toml
+++ b/roslibrust_rosapi/Cargo.toml
@@ -9,7 +9,7 @@ roslibrust = { path = "../roslibrust", features = ["macro"] }
 [dev-dependencies]
 roslibrust = { path = "../roslibrust", features = ["rosbridge"] }
 tokio = { workspace = true }
-test-log = "0.2"
+test-log = { workspace = true }
 
 [features]
 # Used to indicate we're executing tests with a running ros1 rosapi node

--- a/roslibrust_rosbridge/Cargo.toml
+++ b/roslibrust_rosbridge/Cargo.toml
@@ -22,7 +22,7 @@ dashmap = "5.3"
 deadqueue = "0.2.4" # .4+ is required to fix bug with missing tokio dep
 
 [dev-dependencies]
-test-log = "0.2"
+test-log = { workspace = true }
 roslibrust_codegen = { path = "../roslibrust_codegen" }
 roslibrust_codegen_macro = { path = "../roslibrust_codegen_macro" }
 roslibrust_test = { path = "../roslibrust_test" }

--- a/roslibrust_rosbridge/src/lib.rs
+++ b/roslibrust_rosbridge/src/lib.rs
@@ -67,7 +67,7 @@ use tokio_tungstenite::*;
 use tungstenite::Message;
 
 /// Used for type erasure of message type so that we can store arbitrary handles
-type Callback = Box<dyn Fn(&str) + Send + Sync>;
+type Callback = std::sync::Arc<dyn Fn(&str) + Send + Sync>;
 
 /// Type erasure of callback for a service
 /// Internally this will covert the input string to the Request type
@@ -78,7 +78,7 @@ type Callback = Box<dyn Fn(&str) + Send + Sync>;
 // I can make a good argument for &str because that should be generic even if we switch
 // backends - Carter 2022-10-6
 // TODO move out of rosbridge and into "common"
-pub(crate) type ServiceCallback = Box<
+pub(crate) type ServiceCallback = std::sync::Arc<
     dyn Fn(&str) -> std::result::Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>
         + Send
         + Sync,

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -14,6 +14,7 @@ log = { workspace = true }
 diffy = "0.3.0"
 criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
 pprof = { version = "0.11", features = ["flamegraph", "criterion"] }
+test-log = { workspace = true }
 
 [[bin]]
 path = "src/performance_ramp.rs"
@@ -22,3 +23,6 @@ name = "ramp"
 [[bench]]
 name = "image_bench"
 harness = false
+
+[features]
+ros1_test = []

--- a/roslibrust_test/tests/ros1_blocking_service_async.rs
+++ b/roslibrust_test/tests/ros1_blocking_service_async.rs
@@ -1,0 +1,56 @@
+//! Test designed to show how to perform async actions in a blocking service callback
+
+/// Tests require a running roscore
+#[cfg(feature = "ros1_test")]
+mod ros1_test {
+    use log::*;
+    use roslibrust::ros1::NodeHandle;
+    use roslibrust_test::ros1::*;
+
+    // This test covers a very specific case.
+    // We previously weren't evaluating user's service functions inside a spawn_blocking call.
+    // This would result in services sometime blocking the tokio runtime,
+    // and prevented users from using Handle::block_on to perform async actions within their services.
+    #[test_log::test(tokio::test)]
+    async fn blocking_service_async() {
+        let nh = NodeHandle::new("http://localhost:11311", "blocking_service_async")
+            .await
+            .unwrap();
+
+        // Using a channel to represent something like another service that a service would like to call
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        let service = move |request: std_srvs::TriggerRequest| {
+            info!("Got request: {request:?}");
+
+            let handle = tokio::runtime::Handle::current();
+
+            // Note: `move` not used here, future only borrows tx
+            handle.block_on(async {
+                let _ = tx.send(()).await;
+            });
+
+            Ok(std_srvs::TriggerResponse {
+                success: true,
+                message: "You triggered me!".to_string(),
+            })
+        };
+
+        let _handle = nh
+            .advertise_service::<std_srvs::Trigger, _>("/trigger", service)
+            .await
+            .unwrap();
+
+        let client = nh
+            .service_client::<std_srvs::Trigger>("/trigger")
+            .await
+            .unwrap();
+
+        let response = client.call(&std_srvs::TriggerRequest {}).await.unwrap();
+
+        rx.recv().await.unwrap();
+
+        assert_eq!(response.success, true);
+        assert_eq!(response.message, "You triggered me!");
+    }
+}


### PR DESCRIPTION
## Description
- Changes all back-ends to always call user provided service functions inside of `spawn_blocking`
- Adds example showing how to perform async operations inside of a service handle
- Adds integration test confirming this behavior for ros1

## Fixes
Closes: #108 

## Checklist
- [x] Update CHANGELOG.md

