### PR TITLE
add more hashes to raw string literal to avoid unusual ros message definition comment problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make unusual ros message definitions less likely to trip up roslibrust_codegen.
+
 ### Changed
 
 ## 0.14.0 - Apr 7th, 2025

--- a/assets/ros1_test_msgs/msg/ADSBVehicle.msg
+++ b/assets/ros1_test_msgs/msg/ADSBVehicle.msg
@@ -1,0 +1,79 @@
+# The location and information of an ADSB vehicle
+#
+# https://mavlink.io/en/messages/common.html#ADSB_VEHICLE
+
+# [[[cog:
+# from pymavlink.dialects.v20 import common
+#
+# def decl_enum(ename, pfx='', bsz=8):
+#     enum = sorted(common.enums[ename].items())
+#     enum.pop() # remove ENUM_END
+#
+#     cog.outl("# " + ename)
+#     for k, e in enum:
+#         sn = e.name[len(ename) + 1:]
+#         l = "uint{bsz} {pfx}{sn} = {k}".format(**locals())
+#         if e.description:
+#             l += ' ' * (40 - len(l)) + ' # ' + e.description
+#         cog.outl(l)
+#
+# decl_enum('ADSB_ALTITUDE_TYPE', 'ALT_')
+# decl_enum('ADSB_EMITTER_TYPE', 'EMITTER_')
+# decl_enum('ADSB_FLAGS', 'FLAG_', 16)
+# ]]]
+# ADSB_ALTITUDE_TYPE
+uint8 ALT_PRESSURE_QNH = 0               # Altitude reported from a Baro source using QNH reference
+uint8 ALT_GEOMETRIC = 1                  # Altitude reported from a GNSS source
+# ADSB_EMITTER_TYPE
+uint8 EMITTER_NO_INFO = 0
+uint8 EMITTER_LIGHT = 1
+uint8 EMITTER_SMALL = 2
+uint8 EMITTER_LARGE = 3
+uint8 EMITTER_HIGH_VORTEX_LARGE = 4
+uint8 EMITTER_HEAVY = 5
+uint8 EMITTER_HIGHLY_MANUV = 6
+uint8 EMITTER_ROTOCRAFT = 7
+uint8 EMITTER_UNASSIGNED = 8
+uint8 EMITTER_GLIDER = 9
+uint8 EMITTER_LIGHTER_AIR = 10
+uint8 EMITTER_PARACHUTE = 11
+uint8 EMITTER_ULTRA_LIGHT = 12
+uint8 EMITTER_UNASSIGNED2 = 13
+uint8 EMITTER_UAV = 14
+uint8 EMITTER_SPACE = 15
+uint8 EMITTER_UNASSGINED3 = 16
+uint8 EMITTER_EMERGENCY_SURFACE = 17
+uint8 EMITTER_SERVICE_SURFACE = 18
+uint8 EMITTER_POINT_OBSTACLE = 19
+# ADSB_FLAGS
+uint16 FLAG_VALID_COORDS = 1
+uint16 FLAG_VALID_ALTITUDE = 2
+uint16 FLAG_VALID_HEADING = 4
+uint16 FLAG_VALID_VELOCITY = 8
+uint16 FLAG_VALID_CALLSIGN = 16
+uint16 FLAG_VALID_SQUAWK = 32
+uint16 FLAG_SIMULATED = 64
+uint16 FLAG_VERTICAL_VELOCITY_VALID = 128
+uint16 FLAG_BARO_VALID = 256
+uint16 FLAG_SOURCE_UAT = 32768
+# [[[end]]] (checksum: a34f2a081739921b6e3e443ed0516d8d)
+
+std_msgs/Header header
+
+uint32 ICAO_address
+string callsign
+
+float64 latitude
+float64 longitude
+float32 altitude 	# AMSL
+
+float32 heading		# deg [0..360)
+float32 hor_velocity	# m/s
+float32 ver_velocity	# m/s
+
+uint8 altitude_type	# Type from ADSB_ALTITUDE_TYPE enum
+uint8 emitter_type	# Type from ADSB_EMITTER_TYPE enum
+
+duration tslc		# Duration from last communication, seconds [0..255]
+uint16 flags		# ADSB_FLAGS bit field
+uint16 squawk		# Squawk code

--- a/roslibrust_codegen/src/gen.rs
+++ b/roslibrust_codegen/src/gen.rs
@@ -53,7 +53,7 @@ pub fn generate_service(service: ServiceFile) -> Result<TokenStream, Error> {
 
 /// Turns a string into a TokenStream that represents a raw string literal of the string
 pub fn generate_raw_string_literal(value: &str) -> TokenStream {
-    let wrapped = format!("r#\"{}\"#", value);
+    let wrapped = format!("r####\"{}\"####", value);
     TokenStream::from_str(&wrapped).unwrap()
 }
 

--- a/roslibrust_test/src/ros1.rs
+++ b/roslibrust_test/src/ros1.rs
@@ -30,7 +30,7 @@ pub mod actionlib_msgs {
     impl ::roslibrust::RosMessageType for GoalID {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalID";
         const MD5SUM: &'static str = "302881f31927c1df708a2dbab0e80ee8";
-        const DEFINITION: &'static str = r#"# The stamp should store the time at which this goal was requested.
+        const DEFINITION: &'static str = r####"# The stamp should store the time at which this goal was requested.
 # It is used by an action server when it tries to preempt all
 # goals that were requested before a certain time
 time stamp
@@ -38,7 +38,7 @@ time stamp
 # The id provides a way to associate feedback and
 # result message with specific goal requests. The id
 # specified must be unique.
-string id"#;
+string id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -58,7 +58,7 @@ string id"#;
     impl ::roslibrust::RosMessageType for GoalStatus {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalStatus";
         const MD5SUM: &'static str = "d388f9b87b3c471f784434d671988d4a";
-        const DEFINITION: &'static str = r#"GoalID goal_id
+        const DEFINITION: &'static str = r####"GoalID goal_id
 uint8 status
 uint8 PENDING         = 0   # The goal has yet to be processed by the action server
 uint8 ACTIVE          = 1   # The goal is currently being processed by the action server
@@ -90,7 +90,7 @@ time stamp
 # The id provides a way to associate feedback and
 # result message with specific goal requests. The id
 # specified must be unique.
-string id"#;
+string id"####;
     }
     #[allow(unused)]
     impl GoalStatus {
@@ -122,7 +122,7 @@ string id"#;
     impl ::roslibrust::RosMessageType for GoalStatusArray {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalStatusArray";
         const MD5SUM: &'static str = "8b2b82f13216d0a8ea88bd3af735e619";
-        const DEFINITION: &'static str = r#"# Stores the statuses for goals that are currently being tracked
+        const DEFINITION: &'static str = r####"# Stores the statuses for goals that are currently being tracked
 # by an action server
 Header header
 GoalStatus[] status_list
@@ -186,7 +186,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -221,7 +221,7 @@ pub mod diagnostic_msgs {
     impl ::roslibrust::RosMessageType for DiagnosticArray {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/DiagnosticArray";
         const MD5SUM: &'static str = "60810da900de1dd6ddd437c3503511da";
-        const DEFINITION: &'static str = r#"# This message is used to send diagnostic information about the state of the robot
+        const DEFINITION: &'static str = r####"# This message is used to send diagnostic information about the state of the robot
 Header header #for timestamp
 DiagnosticStatus[] status # an array of components being reported on
 ================================================================================
@@ -262,7 +262,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -284,7 +284,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for DiagnosticStatus {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/DiagnosticStatus";
         const MD5SUM: &'static str = "d0ce08bc6e5ba34c7754f563a9cabaf1";
-        const DEFINITION: &'static str = r#"# This message holds the status of an individual component of the robot.
+        const DEFINITION: &'static str = r####"# This message holds the status of an individual component of the robot.
 # 
 
 # Possible levels of operations
@@ -301,7 +301,7 @@ KeyValue[] values # an array of values associated with the status
 ================================================================================
 MSG: diagnostic_msgs/KeyValue
 string key # what to label this value when viewing
-string value # a value to track over time"#;
+string value # a value to track over time"####;
     }
     #[allow(unused)]
     impl DiagnosticStatus {
@@ -327,8 +327,8 @@ string value # a value to track over time"#;
     impl ::roslibrust::RosMessageType for KeyValue {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/KeyValue";
         const MD5SUM: &'static str = "cf57fdc6617a881a88c16e768132149c";
-        const DEFINITION: &'static str = r#"string key # what to label this value when viewing
-string value # a value to track over time"#;
+        const DEFINITION: &'static str = r####"string key # what to label this value when viewing
+string value # a value to track over time"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -346,7 +346,7 @@ string value # a value to track over time"#;
     impl ::roslibrust::RosMessageType for AddDiagnosticsRequest {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/AddDiagnosticsRequest";
         const MD5SUM: &'static str = "c26cf6e164288fbc6050d74f838bcdf0";
-        const DEFINITION: &'static str = r#"# This service is used as part of the process for loading analyzers at runtime,
+        const DEFINITION: &'static str = r####"# This service is used as part of the process for loading analyzers at runtime,
 # and should be used by a loader script or program, not as a standalone service.
 # Information about dynamic addition of analyzers can be found at
 # http://wiki.ros.org/diagnostics/Tutorials/Adding%20Analyzers%20at%20Runtime
@@ -362,7 +362,7 @@ string value # a value to track over time"#;
 # and http://wiki.ros.org/diagnostics/Tutorials/Using%20the%20GenericAnalyzer
 # for examples of the structure of yaml files which are expected to have been
 # loaded into the namespace.
-string load_namespace"#;
+string load_namespace"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -381,14 +381,14 @@ string load_namespace"#;
     impl ::roslibrust::RosMessageType for AddDiagnosticsResponse {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/AddDiagnosticsResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"# True if diagnostic aggregator was updated with new diagnostics, False
+        const DEFINITION: &'static str = r####"# True if diagnostic aggregator was updated with new diagnostics, False
 # otherwise. A false return value means that either there is a bond in the
 # aggregator which already used the requested namespace, or the initialization
 # of analyzers failed.
 bool success
 
 # Message with additional information about the success or failure
-string message"#;
+string message"####;
     }
     #[allow(dead_code)]
     pub struct AddDiagnostics {}
@@ -412,7 +412,7 @@ string message"#;
     impl ::roslibrust::RosMessageType for SelfTestRequest {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/SelfTestRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -432,7 +432,7 @@ string message"#;
     impl ::roslibrust::RosMessageType for SelfTestResponse {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/SelfTestResponse";
         const MD5SUM: &'static str = "ac21b1bab7ab17546986536c22eb34e9";
-        const DEFINITION: &'static str = r#"string id
+        const DEFINITION: &'static str = r####"string id
 byte passed
 DiagnosticStatus[] status
 ================================================================================
@@ -458,7 +458,7 @@ string value # a value to track over time
 ================================================================================
 MSG: diagnostic_msgs/KeyValue
 string key # what to label this value when viewing
-string value # a value to track over time"#;
+string value # a value to track over time"####;
     }
     #[allow(dead_code)]
     pub struct SelfTest {}
@@ -501,7 +501,7 @@ pub mod geometry_msgs {
     impl ::roslibrust::RosMessageType for Accel {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Accel";
         const MD5SUM: &'static str = "9f195f881246fdfa2798d1d3eebca84a";
-        const DEFINITION: &'static str = r#"# This expresses acceleration in free space broken into its linear and angular parts.
+        const DEFINITION: &'static str = r####"# This expresses acceleration in free space broken into its linear and angular parts.
 Vector3  linear
 Vector3  angular
 ================================================================================
@@ -515,7 +515,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -534,7 +534,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for AccelStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelStamped";
         const MD5SUM: &'static str = "d8a98a5d81351b6eb0578c78557e7659";
-        const DEFINITION: &'static str = r#"# An accel with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# An accel with reference coordinate frame and timestamp
 Header header
 Accel accel
 ================================================================================
@@ -580,7 +580,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -601,7 +601,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
         const MD5SUM: &'static str = "ad5a718d699c6be72a02b8d6a139f334";
-        const DEFINITION: &'static str = r#"# This expresses acceleration in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This expresses acceleration in free space with uncertainty.
 
 Accel accel
 
@@ -638,7 +638,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -657,7 +657,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for AccelWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovarianceStamped";
         const MD5SUM: &'static str = "96adb295225031ec8d57fb4251b0a886";
-        const DEFINITION: &'static str = r#"# This represents an estimated accel with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an estimated accel with reference coordinate frame and timestamp.
 Header header
 AccelWithCovariance accel
 ================================================================================
@@ -743,7 +743,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -768,7 +768,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Inertia {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Inertia";
         const MD5SUM: &'static str = "1d26e4bb6c83ff141c5cf0d883c2b0fe";
-        const DEFINITION: &'static str = r#"# Mass [kg]
+        const DEFINITION: &'static str = r####"# Mass [kg]
 float64 m
 
 # Center of mass [m]
@@ -795,7 +795,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -814,7 +814,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for InertiaStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/InertiaStamped";
         const MD5SUM: &'static str = "ddee48caeab5a966c5e8d166654a9ac7";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 Inertia inertia
 ================================================================================
 MSG: geometry_msgs/Inertia
@@ -872,7 +872,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -892,10 +892,10 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Point {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Point";
         const MD5SUM: &'static str = "4a842b65f413084dc2b10fb484ea7f17";
-        const DEFINITION: &'static str = r#"# This contains the position of a point in free space
+        const DEFINITION: &'static str = r####"# This contains the position of a point in free space
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -915,7 +915,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for Point32 {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Point32";
         const MD5SUM: &'static str = "cc153912f1453b708d221682bc23d9ac";
-        const DEFINITION: &'static str = r#"# This contains the position of a point in free space(with 32 bits of precision).
+        const DEFINITION: &'static str = r####"# This contains the position of a point in free space(with 32 bits of precision).
 # It is recommeded to use Point wherever possible instead of Point32.  
 # 
 # This recommendation is to promote interoperability.  
@@ -925,7 +925,7 @@ float64 z"#;
 
 float32 x
 float32 y
-float32 z"#;
+float32 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -944,7 +944,7 @@ float32 z"#;
     impl ::roslibrust::RosMessageType for PointStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PointStamped";
         const MD5SUM: &'static str = "c63aecb41bfdfd6b7e1fac37c7cbe7bf";
-        const DEFINITION: &'static str = r#"# This represents a Point with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Point with reference coordinate frame and timestamp
 Header header
 Point point
 ================================================================================
@@ -967,7 +967,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -985,7 +985,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Polygon {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Polygon";
         const MD5SUM: &'static str = "cd60a26494a087f577976f0329fa120e";
-        const DEFINITION: &'static str = r#"#A specification of a polygon where the first and last points are assumed to be connected
+        const DEFINITION: &'static str = r####"#A specification of a polygon where the first and last points are assumed to be connected
 Point32[] points
 ================================================================================
 MSG: geometry_msgs/Point32
@@ -999,7 +999,7 @@ MSG: geometry_msgs/Point32
 
 float32 x
 float32 y
-float32 z"#;
+float32 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1018,7 +1018,7 @@ float32 z"#;
     impl ::roslibrust::RosMessageType for PolygonStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PolygonStamped";
         const MD5SUM: &'static str = "c6be8f7dc3bee7fe9e8d296070f53340";
-        const DEFINITION: &'static str = r#"# This represents a Polygon with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Polygon with reference coordinate frame and timestamp
 Header header
 Polygon polygon
 ================================================================================
@@ -1065,7 +1065,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1084,7 +1084,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Pose {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Pose";
         const MD5SUM: &'static str = "e45d45a5a1ce597b249e23fb30fc871f";
-        const DEFINITION: &'static str = r#"# A representation of pose in free space, composed of position and orientation. 
+        const DEFINITION: &'static str = r####"# A representation of pose in free space, composed of position and orientation. 
 Point position
 Quaternion orientation
 ================================================================================
@@ -1100,7 +1100,7 @@ MSG: geometry_msgs/Quaternion
 float64 x
 float64 y
 float64 z
-float64 w"#;
+float64 w"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1120,7 +1120,7 @@ float64 w"#;
     impl ::roslibrust::RosMessageType for Pose2D {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Pose2D";
         const MD5SUM: &'static str = "938fa65709584ad8e77d238529be13b8";
-        const DEFINITION: &'static str = r#"# Deprecated
+        const DEFINITION: &'static str = r####"# Deprecated
 # Please use the full 3D pose.
 
 # In general our recommendation is to use a full 3D representation of everything and for 2D specific applications make the appropriate projections into the plane for their calculations but optimally will preserve the 3D information during processing.
@@ -1132,7 +1132,7 @@ float64 w"#;
 
 float64 x
 float64 y
-float64 theta"#;
+float64 theta"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1151,7 +1151,7 @@ float64 theta"#;
     impl ::roslibrust::RosMessageType for PoseArray {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseArray";
         const MD5SUM: &'static str = "916c28c5764443f268b296bb671b9d97";
-        const DEFINITION: &'static str = r#"# An array of poses with a header for global reference.
+        const DEFINITION: &'static str = r####"# An array of poses with a header for global reference.
 
 Header header
 
@@ -1203,7 +1203,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1222,7 +1222,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PoseStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseStamped";
         const MD5SUM: &'static str = "d3812c3cbc69362b77dc0b19b345f8f5";
-        const DEFINITION: &'static str = r#"# A Pose with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A Pose with reference coordinate frame and timestamp
 Header header
 Pose pose
 ================================================================================
@@ -1272,7 +1272,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1293,7 +1293,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
         const MD5SUM: &'static str = "c23e848cf1b7533a8d7c259073a97e6f";
-        const DEFINITION: &'static str = r#"# This represents a pose in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This represents a pose in free space with uncertainty.
 
 Pose pose
 
@@ -1334,7 +1334,7 @@ MSG: geometry_msgs/Quaternion
 float64 x
 float64 y
 float64 z
-float64 w"#;
+float64 w"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1353,7 +1353,7 @@ float64 w"#;
     impl ::roslibrust::RosMessageType for PoseWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovarianceStamped";
         const MD5SUM: &'static str = "953b798c0f514ff060a53a3498ce6246";
-        const DEFINITION: &'static str = r#"# This expresses an estimated pose with a reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This expresses an estimated pose with a reference coordinate frame and timestamp
 
 Header header
 PoseWithCovariance pose
@@ -1448,7 +1448,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1469,12 +1469,12 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Quaternion {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Quaternion";
         const MD5SUM: &'static str = "a779879fadf0160734f906b8c19c7004";
-        const DEFINITION: &'static str = r#"# This represents an orientation in free space in quaternion form.
+        const DEFINITION: &'static str = r####"# This represents an orientation in free space in quaternion form.
 
 float64 x
 float64 y
 float64 z
-float64 w"#;
+float64 w"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1493,7 +1493,7 @@ float64 w"#;
     impl ::roslibrust::RosMessageType for QuaternionStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/QuaternionStamped";
         const MD5SUM: &'static str = "e57f1e547e0e1fd13504588ffc8334e2";
-        const DEFINITION: &'static str = r#"# This represents an orientation with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an orientation with reference coordinate frame and timestamp.
 
 Header header
 Quaternion quaternion
@@ -1519,7 +1519,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1538,7 +1538,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Transform {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Transform";
         const MD5SUM: &'static str = "ac9eff44abf714214112b05d54a3cf9b";
-        const DEFINITION: &'static str = r#"# This represents the transform between two coordinate frames in free space.
+        const DEFINITION: &'static str = r####"# This represents the transform between two coordinate frames in free space.
 
 Vector3 translation
 Quaternion rotation
@@ -1561,7 +1561,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1581,7 +1581,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TransformStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TransformStamped";
         const MD5SUM: &'static str = "b5764a33bfeb3588febc2682852579b0";
-        const DEFINITION: &'static str = r#"# This expresses a transform from coordinate frame header.frame_id
+        const DEFINITION: &'static str = r####"# This expresses a transform from coordinate frame header.frame_id
 # to the coordinate frame child_frame_id
 #
 # This message is mostly used by the 
@@ -1651,7 +1651,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1670,7 +1670,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Twist {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Twist";
         const MD5SUM: &'static str = "9f195f881246fdfa2798d1d3eebca84a";
-        const DEFINITION: &'static str = r#"# This expresses velocity in free space broken into its linear and angular parts.
+        const DEFINITION: &'static str = r####"# This expresses velocity in free space broken into its linear and angular parts.
 Vector3  linear
 Vector3  angular
 ================================================================================
@@ -1684,7 +1684,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1703,7 +1703,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TwistStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistStamped";
         const MD5SUM: &'static str = "98d34b0043a2093cf9d9345ab6eef12e";
-        const DEFINITION: &'static str = r#"# A twist with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A twist with reference coordinate frame and timestamp
 Header header
 Twist twist
 ================================================================================
@@ -1749,7 +1749,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1770,7 +1770,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
         const MD5SUM: &'static str = "1fe8a28e6890a4cc3ae4c3ca5c7d82e6";
-        const DEFINITION: &'static str = r#"# This expresses velocity in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This expresses velocity in free space with uncertainty.
 
 Twist twist
 
@@ -1807,7 +1807,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1826,7 +1826,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TwistWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovarianceStamped";
         const MD5SUM: &'static str = "8927a1a12fb2607ceea095b2dc440a96";
-        const DEFINITION: &'static str = r#"# This represents an estimated twist with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an estimated twist with reference coordinate frame and timestamp.
 Header header
 TwistWithCovariance twist
 ================================================================================
@@ -1912,7 +1912,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1932,7 +1932,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Vector3 {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Vector3";
         const MD5SUM: &'static str = "4a842b65f413084dc2b10fb484ea7f17";
-        const DEFINITION: &'static str = r#"# This represents a vector in free space. 
+        const DEFINITION: &'static str = r####"# This represents a vector in free space. 
 # It is only meant to represent a direction. Therefore, it does not
 # make sense to apply a translation to it (e.g., when applying a 
 # generic rigid transformation to a Vector3, tf2 will only apply the
@@ -1941,7 +1941,7 @@ string frame_id"#;
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1960,7 +1960,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for Vector3Stamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Vector3Stamped";
         const MD5SUM: &'static str = "7b324c7325e683bf02a9b14b01090ec7";
-        const DEFINITION: &'static str = r#"# This represents a Vector3 with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Vector3 with reference coordinate frame and timestamp
 Header header
 Vector3 vector
 ================================================================================
@@ -1989,7 +1989,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2008,7 +2008,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Wrench {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Wrench";
         const MD5SUM: &'static str = "4f539cf138b23283b520fd271b567936";
-        const DEFINITION: &'static str = r#"# This represents force in free space, separated into
+        const DEFINITION: &'static str = r####"# This represents force in free space, separated into
 # its linear and angular parts.
 Vector3  force
 Vector3  torque
@@ -2023,7 +2023,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2042,7 +2042,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for WrenchStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/WrenchStamped";
         const MD5SUM: &'static str = "d78d3cb249ce23087ade7e7d0c40cfa7";
-        const DEFINITION: &'static str = r#"# A wrench with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A wrench with reference coordinate frame and timestamp
 Header header
 Wrench wrench
 ================================================================================
@@ -2089,7 +2089,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -2125,7 +2125,7 @@ pub mod nav_msgs {
     impl ::roslibrust::RosMessageType for GetMapAction {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapAction";
         const MD5SUM: &'static str = "e611ad23fbf237c031b7536416dc7cd7";
-        const DEFINITION: &'static str = r#"GetMapActionGoal action_goal
+        const DEFINITION: &'static str = r####"GetMapActionGoal action_goal
 GetMapActionResult action_result
 GetMapActionFeedback action_feedback
 ================================================================================
@@ -3159,7 +3159,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3179,7 +3179,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapActionFeedback {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapActionFeedback";
         const MD5SUM: &'static str = "aae20e09065c3809e8a8e87c4c8953fd";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 actionlib_msgs/GoalStatus status
 GetMapFeedback feedback
 ================================================================================
@@ -3245,7 +3245,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3265,7 +3265,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapActionGoal {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapActionGoal";
         const MD5SUM: &'static str = "4b30be6cd12b9e72826df56b481f40e0";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 actionlib_msgs/GoalID goal_id
 GetMapGoal goal
 ================================================================================
@@ -3296,7 +3296,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3316,7 +3316,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapActionResult {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapActionResult";
         const MD5SUM: &'static str = "ac66e5b9a79bb4bbd33dab245236c892";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 actionlib_msgs/GoalStatus status
 GetMapResult result
 ================================================================================
@@ -3777,7 +3777,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3793,7 +3793,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapFeedback {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapFeedback";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#"# no feedback"#;
+        const DEFINITION: &'static str = r####"# no feedback"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3809,7 +3809,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapGoal {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapGoal";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#"# Get the map as a nav_msgs/OccupancyGrid"#;
+        const DEFINITION: &'static str = r####"# Get the map as a nav_msgs/OccupancyGrid"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3827,7 +3827,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapResult {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapResult";
         const MD5SUM: &'static str = "6cdd0a18e0aff5b0a3ca2326a89b54ff";
-        const DEFINITION: &'static str = r#"nav_msgs/OccupancyGrid map
+        const DEFINITION: &'static str = r####"nav_msgs/OccupancyGrid map
 ================================================================================
 MSG: geometry_msgs/Point
 # This contains the position of a point in free space
@@ -4032,7 +4032,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4053,7 +4053,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GridCells {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GridCells";
         const MD5SUM: &'static str = "b9e4f5df6d28e272ebde00a3994830f5";
-        const DEFINITION: &'static str = r#"#an array of cells in a 2D grid
+        const DEFINITION: &'static str = r####"#an array of cells in a 2D grid
 Header header
 float32 cell_width
 float32 cell_height
@@ -4078,7 +4078,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4100,7 +4100,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MapMetaData {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/MapMetaData";
         const MD5SUM: &'static str = "10cfc8a2818024d3248802c00c95f11b";
-        const DEFINITION: &'static str = r#"# This hold basic information about the characterists of the OccupancyGrid
+        const DEFINITION: &'static str = r####"# This hold basic information about the characterists of the OccupancyGrid
 
 # The time at which the map was loaded
 time map_load_time
@@ -4145,7 +4145,7 @@ MSG: geometry_msgs/Quaternion
 float64 x
 float64 y
 float64 z
-float64 w"#;
+float64 w"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4165,7 +4165,7 @@ float64 w"#;
     impl ::roslibrust::RosMessageType for OccupancyGrid {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/OccupancyGrid";
         const MD5SUM: &'static str = "3381f2d731d4076ec5c71b0759edbe4e";
-        const DEFINITION: &'static str = r#"# This represents a 2-D grid map, in which each cell represents the probability of
+        const DEFINITION: &'static str = r####"# This represents a 2-D grid map, in which each cell represents the probability of
 # occupancy.
 
 Header header 
@@ -4271,7 +4271,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4292,7 +4292,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Odometry {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Odometry";
         const MD5SUM: &'static str = "cd5e73d190d741a2f92e81eda573aca7";
-        const DEFINITION: &'static str = r#"# This represents an estimate of a position and velocity in free space.  
+        const DEFINITION: &'static str = r####"# This represents an estimate of a position and velocity in free space.  
 # The pose in this message should be specified in the coordinate frame given by header.frame_id.
 # The twist in this message should be specified in the coordinate frame given by the child_frame_id
 Header header
@@ -4459,7 +4459,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4478,7 +4478,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Path {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Path";
         const MD5SUM: &'static str = "6227e2b7e9cce15051f669a5e197bbf7";
-        const DEFINITION: &'static str = r#"#An array of poses that represents a Path for a robot to follow
+        const DEFINITION: &'static str = r####"#An array of poses that represents a Path for a robot to follow
 Header header
 geometry_msgs/PoseStamped[] poses
 ================================================================================
@@ -4581,7 +4581,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4597,7 +4597,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#"# Get the map as a nav_msgs/OccupancyGrid"#;
+        const DEFINITION: &'static str = r####"# Get the map as a nav_msgs/OccupancyGrid"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4615,7 +4615,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapResponse";
         const MD5SUM: &'static str = "6cdd0a18e0aff5b0a3ca2326a89b54ff";
-        const DEFINITION: &'static str = r#"nav_msgs/OccupancyGrid map
+        const DEFINITION: &'static str = r####"nav_msgs/OccupancyGrid map
 ================================================================================
 MSG: geometry_msgs/Point
 # This contains the position of a point in free space
@@ -4820,7 +4820,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(dead_code)]
     pub struct GetMap {}
@@ -4848,7 +4848,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetPlanRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetPlanRequest";
         const MD5SUM: &'static str = "e25a43e0752bcca599a8c2eef8282df8";
-        const DEFINITION: &'static str = r#"# Get a plan from the current position to the goal Pose 
+        const DEFINITION: &'static str = r####"# Get a plan from the current position to the goal Pose 
 
 # The start pose for the plan
 geometry_msgs/PoseStamped start
@@ -4959,7 +4959,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4977,7 +4977,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetPlanResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetPlanResponse";
         const MD5SUM: &'static str = "0002bc113c0259d71f6cf8cbc9430e18";
-        const DEFINITION: &'static str = r#"nav_msgs/Path plan
+        const DEFINITION: &'static str = r####"nav_msgs/Path plan
 ================================================================================
 MSG: geometry_msgs/Point
 # This contains the position of a point in free space
@@ -5184,7 +5184,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(dead_code)]
     pub struct GetPlan {}
@@ -5210,10 +5210,10 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for LoadMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/LoadMapRequest";
         const MD5SUM: &'static str = "3813ba1ae85fbcd4dc88c90f1426b90b";
-        const DEFINITION: &'static str = r#"# URL of map resource
+        const DEFINITION: &'static str = r####"# URL of map resource
 # Can be an absolute path to a file: file:///path/to/maps/floor1.yaml
 # Or, relative to a ROS package: package://my_ros_package/maps/floor2.yaml
-string map_url"#;
+string map_url"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5232,7 +5232,7 @@ string map_url"#;
     impl ::roslibrust::RosMessageType for LoadMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/LoadMapResponse";
         const MD5SUM: &'static str = "079b9c828e9f7c1918bf86932fd7267e";
-        const DEFINITION: &'static str = r#"# Result code defintions
+        const DEFINITION: &'static str = r####"# Result code defintions
 uint8 RESULT_SUCCESS=0
 uint8 RESULT_MAP_DOES_NOT_EXIST=1
 uint8 RESULT_INVALID_MAP_DATA=2
@@ -5446,7 +5446,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl LoadMapResponse {
@@ -5481,7 +5481,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapRequest";
         const MD5SUM: &'static str = "91149a20d7be299b87c340df8cc94fd4";
-        const DEFINITION: &'static str = r#"# Set a new map together with an initial pose
+        const DEFINITION: &'static str = r####"# Set a new map together with an initial pose
 nav_msgs/OccupancyGrid map
 geometry_msgs/PoseWithCovarianceStamped initial_pose
 ================================================================================
@@ -5830,7 +5830,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5848,7 +5848,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapResponse";
         const MD5SUM: &'static str = "358e233cde0c8a8bcfea4ce193f8fc15";
-        const DEFINITION: &'static str = r#"bool success"#;
+        const DEFINITION: &'static str = r####"bool success"####;
     }
     #[allow(dead_code)]
     pub struct SetMap {}
@@ -5896,13 +5896,13 @@ pub mod rosapi {
     impl ::roslibrust::RosMessageType for TypeDef {
         const ROS_TYPE_NAME: &'static str = "rosapi/TypeDef";
         const MD5SUM: &'static str = "80597571d79bbeef6c9c4d98f30116a0";
-        const DEFINITION: &'static str = r#"string type
+        const DEFINITION: &'static str = r####"string type
 string[] fieldnames
 string[] fieldtypes
 int32[] fieldarraylen
 string[] examples
 string[] constnames
-string[] constvalues"#;
+string[] constvalues"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5920,7 +5920,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for DeleteParamRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/DeleteParamRequest";
         const MD5SUM: &'static str = "c1f3d28f1b044c871e6eff2e9fc3c667";
-        const DEFINITION: &'static str = r#"string name"#;
+        const DEFINITION: &'static str = r####"string name"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5936,7 +5936,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for DeleteParamResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/DeleteParamResponse";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(dead_code)]
     pub struct DeleteParam {}
@@ -5960,7 +5960,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for GetActionServersRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetActionServersRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5978,7 +5978,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for GetActionServersResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetActionServersResponse";
         const MD5SUM: &'static str = "46807ba271844ac5ba4730a47556b236";
-        const DEFINITION: &'static str = r#"string[] action_servers"#;
+        const DEFINITION: &'static str = r####"string[] action_servers"####;
     }
     #[allow(dead_code)]
     pub struct GetActionServers {}
@@ -6005,8 +6005,8 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for GetParamRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetParamRequest";
         const MD5SUM: &'static str = "1cc3f281ee24ba9406c3e498e4da686f";
-        const DEFINITION: &'static str = r#"string name
-string default"#;
+        const DEFINITION: &'static str = r####"string name
+string default"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6024,7 +6024,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for GetParamResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetParamResponse";
         const MD5SUM: &'static str = "64e58419496c7248b4ef25731f88b8c3";
-        const DEFINITION: &'static str = r#"string value"#;
+        const DEFINITION: &'static str = r####"string value"####;
     }
     #[allow(dead_code)]
     pub struct GetParam {}
@@ -6048,7 +6048,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for GetParamNamesRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetParamNamesRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6066,7 +6066,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for GetParamNamesResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetParamNamesResponse";
         const MD5SUM: &'static str = "dc7ae3609524b18034e49294a4ce670e";
-        const DEFINITION: &'static str = r#"string[] names"#;
+        const DEFINITION: &'static str = r####"string[] names"####;
     }
     #[allow(dead_code)]
     pub struct GetParamNames {}
@@ -6090,7 +6090,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for GetTimeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetTimeRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6108,7 +6108,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for GetTimeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/GetTimeResponse";
         const MD5SUM: &'static str = "556a4fb76023a469987922359d08a844";
-        const DEFINITION: &'static str = r#"time time"#;
+        const DEFINITION: &'static str = r####"time time"####;
     }
     #[allow(dead_code)]
     pub struct GetTime {}
@@ -6134,7 +6134,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for HasParamRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/HasParamRequest";
         const MD5SUM: &'static str = "c1f3d28f1b044c871e6eff2e9fc3c667";
-        const DEFINITION: &'static str = r#"string name"#;
+        const DEFINITION: &'static str = r####"string name"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6152,7 +6152,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for HasParamResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/HasParamResponse";
         const MD5SUM: &'static str = "e8c90de4adc1219c86af9c2874c0c1b5";
-        const DEFINITION: &'static str = r#"bool exists"#;
+        const DEFINITION: &'static str = r####"bool exists"####;
     }
     #[allow(dead_code)]
     pub struct HasParam {}
@@ -6178,7 +6178,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for MessageDetailsRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/MessageDetailsRequest";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6196,7 +6196,7 @@ string default"#;
     impl ::roslibrust::RosMessageType for MessageDetailsResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/MessageDetailsResponse";
         const MD5SUM: &'static str = "a6b8995777f214f2ed97a1e4890feb10";
-        const DEFINITION: &'static str = r#"TypeDef[] typedefs
+        const DEFINITION: &'static str = r####"TypeDef[] typedefs
 ================================================================================
 MSG: rosapi/TypeDef
 string type
@@ -6205,7 +6205,7 @@ string[] fieldtypes
 int32[] fieldarraylen
 string[] examples
 string[] constnames
-string[] constvalues"#;
+string[] constvalues"####;
     }
     #[allow(dead_code)]
     pub struct MessageDetails {}
@@ -6231,7 +6231,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for NodeDetailsRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/NodeDetailsRequest";
         const MD5SUM: &'static str = "a94c40e70a4b82863e6e52ec16732447";
-        const DEFINITION: &'static str = r#"string node"#;
+        const DEFINITION: &'static str = r####"string node"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6251,9 +6251,9 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for NodeDetailsResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/NodeDetailsResponse";
         const MD5SUM: &'static str = "3da1cb16c6ec5885ad291735b6244a48";
-        const DEFINITION: &'static str = r#"string[] subscribing
+        const DEFINITION: &'static str = r####"string[] subscribing
 string[] publishing
-string[] services"#;
+string[] services"####;
     }
     #[allow(dead_code)]
     pub struct NodeDetails {}
@@ -6277,7 +6277,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for NodesRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/NodesRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6295,7 +6295,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for NodesResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/NodesResponse";
         const MD5SUM: &'static str = "3d07bfda1268b4f76b16b7ba8a82665d";
-        const DEFINITION: &'static str = r#"string[] nodes"#;
+        const DEFINITION: &'static str = r####"string[] nodes"####;
     }
     #[allow(dead_code)]
     pub struct Nodes {}
@@ -6321,7 +6321,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for PublishersRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/PublishersRequest";
         const MD5SUM: &'static str = "d8f94bae31b356b24d0427f80426d0c3";
-        const DEFINITION: &'static str = r#"string topic"#;
+        const DEFINITION: &'static str = r####"string topic"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6339,7 +6339,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for PublishersResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/PublishersResponse";
         const MD5SUM: &'static str = "167d8030c4ca4018261dff8ae5083dc8";
-        const DEFINITION: &'static str = r#"string[] publishers"#;
+        const DEFINITION: &'static str = r####"string[] publishers"####;
     }
     #[allow(dead_code)]
     pub struct Publishers {}
@@ -6365,7 +6365,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for SearchParamRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/SearchParamRequest";
         const MD5SUM: &'static str = "c1f3d28f1b044c871e6eff2e9fc3c667";
-        const DEFINITION: &'static str = r#"string name"#;
+        const DEFINITION: &'static str = r####"string name"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6383,7 +6383,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for SearchParamResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/SearchParamResponse";
         const MD5SUM: &'static str = "87c264f142c2aeca13349d90aeec0386";
-        const DEFINITION: &'static str = r#"string global_name"#;
+        const DEFINITION: &'static str = r####"string global_name"####;
     }
     #[allow(dead_code)]
     pub struct SearchParam {}
@@ -6409,7 +6409,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceHostRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceHostRequest";
         const MD5SUM: &'static str = "1cbcfa13b08f6d36710b9af8741e6112";
-        const DEFINITION: &'static str = r#"string service"#;
+        const DEFINITION: &'static str = r####"string service"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6427,7 +6427,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceHostResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceHostResponse";
         const MD5SUM: &'static str = "092ff9f63242a37704ce411703ec5eaf";
-        const DEFINITION: &'static str = r#"string host"#;
+        const DEFINITION: &'static str = r####"string host"####;
     }
     #[allow(dead_code)]
     pub struct ServiceHost {}
@@ -6453,7 +6453,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceNodeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceNodeRequest";
         const MD5SUM: &'static str = "1cbcfa13b08f6d36710b9af8741e6112";
-        const DEFINITION: &'static str = r#"string service"#;
+        const DEFINITION: &'static str = r####"string service"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6471,7 +6471,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceNodeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceNodeResponse";
         const MD5SUM: &'static str = "a94c40e70a4b82863e6e52ec16732447";
-        const DEFINITION: &'static str = r#"string node"#;
+        const DEFINITION: &'static str = r####"string node"####;
     }
     #[allow(dead_code)]
     pub struct ServiceNode {}
@@ -6497,7 +6497,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceProvidersRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceProvidersRequest";
         const MD5SUM: &'static str = "1cbcfa13b08f6d36710b9af8741e6112";
-        const DEFINITION: &'static str = r#"string service"#;
+        const DEFINITION: &'static str = r####"string service"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6515,7 +6515,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceProvidersResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceProvidersResponse";
         const MD5SUM: &'static str = "945f6849f44f061c178ab393b12c1358";
-        const DEFINITION: &'static str = r#"string[] providers"#;
+        const DEFINITION: &'static str = r####"string[] providers"####;
     }
     #[allow(dead_code)]
     pub struct ServiceProviders {}
@@ -6541,7 +6541,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceRequestDetailsRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceRequestDetailsRequest";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6559,7 +6559,7 @@ string[] services"#;
     impl ::roslibrust::RosMessageType for ServiceRequestDetailsResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceRequestDetailsResponse";
         const MD5SUM: &'static str = "a6b8995777f214f2ed97a1e4890feb10";
-        const DEFINITION: &'static str = r#"TypeDef[] typedefs
+        const DEFINITION: &'static str = r####"TypeDef[] typedefs
 ================================================================================
 MSG: rosapi/TypeDef
 string type
@@ -6568,7 +6568,7 @@ string[] fieldtypes
 int32[] fieldarraylen
 string[] examples
 string[] constnames
-string[] constvalues"#;
+string[] constvalues"####;
     }
     #[allow(dead_code)]
     pub struct ServiceRequestDetails {}
@@ -6594,7 +6594,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServiceResponseDetailsRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceResponseDetailsRequest";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6612,7 +6612,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServiceResponseDetailsResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceResponseDetailsResponse";
         const MD5SUM: &'static str = "a6b8995777f214f2ed97a1e4890feb10";
-        const DEFINITION: &'static str = r#"TypeDef[] typedefs
+        const DEFINITION: &'static str = r####"TypeDef[] typedefs
 ================================================================================
 MSG: rosapi/TypeDef
 string type
@@ -6621,7 +6621,7 @@ string[] fieldtypes
 int32[] fieldarraylen
 string[] examples
 string[] constnames
-string[] constvalues"#;
+string[] constvalues"####;
     }
     #[allow(dead_code)]
     pub struct ServiceResponseDetails {}
@@ -6647,7 +6647,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServiceTypeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceTypeRequest";
         const MD5SUM: &'static str = "1cbcfa13b08f6d36710b9af8741e6112";
-        const DEFINITION: &'static str = r#"string service"#;
+        const DEFINITION: &'static str = r####"string service"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6665,7 +6665,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServiceTypeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServiceTypeResponse";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(dead_code)]
     pub struct ServiceType {}
@@ -6689,7 +6689,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServicesRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServicesRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6707,7 +6707,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServicesResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServicesResponse";
         const MD5SUM: &'static str = "e44a7e7bcb900acadbcc28b132378f0c";
-        const DEFINITION: &'static str = r#"string[] services"#;
+        const DEFINITION: &'static str = r####"string[] services"####;
     }
     #[allow(dead_code)]
     pub struct Services {}
@@ -6733,7 +6733,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServicesForTypeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServicesForTypeRequest";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6751,7 +6751,7 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for ServicesForTypeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/ServicesForTypeResponse";
         const MD5SUM: &'static str = "e44a7e7bcb900acadbcc28b132378f0c";
-        const DEFINITION: &'static str = r#"string[] services"#;
+        const DEFINITION: &'static str = r####"string[] services"####;
     }
     #[allow(dead_code)]
     pub struct ServicesForType {}
@@ -6778,8 +6778,8 @@ string[] constvalues"#;
     impl ::roslibrust::RosMessageType for SetParamRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/SetParamRequest";
         const MD5SUM: &'static str = "bc6ccc4a57f61779c8eaae61e9f422e0";
-        const DEFINITION: &'static str = r#"string name
-string value"#;
+        const DEFINITION: &'static str = r####"string name
+string value"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6795,7 +6795,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for SetParamResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/SetParamResponse";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(dead_code)]
     pub struct SetParam {}
@@ -6821,7 +6821,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for SubscribersRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/SubscribersRequest";
         const MD5SUM: &'static str = "d8f94bae31b356b24d0427f80426d0c3";
-        const DEFINITION: &'static str = r#"string topic"#;
+        const DEFINITION: &'static str = r####"string topic"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6839,7 +6839,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for SubscribersResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/SubscribersResponse";
         const MD5SUM: &'static str = "22418cab5ba9531d8c2b738b4e56153b";
-        const DEFINITION: &'static str = r#"string[] subscribers"#;
+        const DEFINITION: &'static str = r####"string[] subscribers"####;
     }
     #[allow(dead_code)]
     pub struct Subscribers {}
@@ -6865,7 +6865,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for TopicTypeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicTypeRequest";
         const MD5SUM: &'static str = "d8f94bae31b356b24d0427f80426d0c3";
-        const DEFINITION: &'static str = r#"string topic"#;
+        const DEFINITION: &'static str = r####"string topic"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6883,7 +6883,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for TopicTypeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicTypeResponse";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(dead_code)]
     pub struct TopicType {}
@@ -6907,7 +6907,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for TopicsRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6926,8 +6926,8 @@ string value"#;
     impl ::roslibrust::RosMessageType for TopicsResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsResponse";
         const MD5SUM: &'static str = "d966d98fc333fa1f3135af765eac1ba8";
-        const DEFINITION: &'static str = r#"string[] topics
-string[] types"#;
+        const DEFINITION: &'static str = r####"string[] topics
+string[] types"####;
     }
     #[allow(dead_code)]
     pub struct Topics {}
@@ -6951,7 +6951,7 @@ string[] types"#;
     impl ::roslibrust::RosMessageType for TopicsAndRawTypesRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsAndRawTypesRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6971,9 +6971,9 @@ string[] types"#;
     impl ::roslibrust::RosMessageType for TopicsAndRawTypesResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsAndRawTypesResponse";
         const MD5SUM: &'static str = "e1432466c8f64316723276ba07c59d12";
-        const DEFINITION: &'static str = r#"string[] topics
+        const DEFINITION: &'static str = r####"string[] topics
 string[] types
-string[] typedefs_full_text"#;
+string[] typedefs_full_text"####;
     }
     #[allow(dead_code)]
     pub struct TopicsAndRawTypes {}
@@ -6999,7 +6999,7 @@ string[] typedefs_full_text"#;
     impl ::roslibrust::RosMessageType for TopicsForTypeRequest {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsForTypeRequest";
         const MD5SUM: &'static str = "dc67331de85cf97091b7d45e5c64ab75";
-        const DEFINITION: &'static str = r#"string type"#;
+        const DEFINITION: &'static str = r####"string type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7017,7 +7017,7 @@ string[] typedefs_full_text"#;
     impl ::roslibrust::RosMessageType for TopicsForTypeResponse {
         const ROS_TYPE_NAME: &'static str = "rosapi/TopicsForTypeResponse";
         const MD5SUM: &'static str = "b0eef9a05d4e829092fc2f2c3c2aad3d";
-        const DEFINITION: &'static str = r#"string[] topics"#;
+        const DEFINITION: &'static str = r####"string[] topics"####;
     }
     #[allow(dead_code)]
     pub struct TopicsForType {}
@@ -7059,10 +7059,10 @@ pub mod rosgraph_msgs {
     impl ::roslibrust::RosMessageType for Clock {
         const ROS_TYPE_NAME: &'static str = "rosgraph_msgs/Clock";
         const MD5SUM: &'static str = "a9c97c1d230cfc112e270351a944ee47";
-        const DEFINITION: &'static str = r#"# roslib/Clock is used for publishing simulated time in ROS. 
+        const DEFINITION: &'static str = r####"# roslib/Clock is used for publishing simulated time in ROS. 
 # This message simply communicates the current time.
 # For more information, see http://www.ros.org/wiki/Clock
-time clock"#;
+time clock"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7087,7 +7087,7 @@ time clock"#;
     impl ::roslibrust::RosMessageType for Log {
         const ROS_TYPE_NAME: &'static str = "rosgraph_msgs/Log";
         const MD5SUM: &'static str = "acffd30cd6b6de30f120938c17c593fb";
-        const DEFINITION: &'static str = r#"##
+        const DEFINITION: &'static str = r####"##
 ## Severity level constants
 ##
 byte DEBUG=1 #debug level
@@ -7120,7 +7120,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl Log {
@@ -7159,7 +7159,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for TopicStatistics {
         const ROS_TYPE_NAME: &'static str = "rosgraph_msgs/TopicStatistics";
         const MD5SUM: &'static str = "10152ed868c5097a5e2e4a89d7daa710";
-        const DEFINITION: &'static str = r#"# name of the topic
+        const DEFINITION: &'static str = r####"# name of the topic
 string topic
 
 # node id of the publisher
@@ -7190,7 +7190,7 @@ duration period_max
 # message does not have a header, it will be 0.
 duration stamp_age_mean
 duration stamp_age_stddev
-duration stamp_age_max"#;
+duration stamp_age_max"####;
     }
 }
 #[allow(unused_imports)]
@@ -7239,7 +7239,7 @@ pub mod sensor_msgs {
     impl ::roslibrust::RosMessageType for BatteryState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/BatteryState";
         const MD5SUM: &'static str = "4ddae7f048e32fda22cac764685e3974";
-        const DEFINITION: &'static str = r#"# Constants are chosen to match the enums in the linux kernel
+        const DEFINITION: &'static str = r####"# Constants are chosen to match the enums in the linux kernel
 # defined in include/linux/power_supply.h as of version 3.7
 # The one difference is for style reasons the constants are
 # all uppercase not mixed case.
@@ -7304,7 +7304,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl BatteryState {
@@ -7356,7 +7356,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for CameraInfo {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CameraInfo";
         const MD5SUM: &'static str = "c9a58c1b0b154e0e6da7578cb991d214";
-        const DEFINITION: &'static str = r#"# This message defines meta information for a camera. It should be in a
+        const DEFINITION: &'static str = r####"# This message defines meta information for a camera. It should be in a
 # camera namespace on topic "camera_info" and accompanied by up to five
 # image topics named:
 #
@@ -7522,7 +7522,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7541,7 +7541,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for ChannelFloat32 {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/ChannelFloat32";
         const MD5SUM: &'static str = "3d40139cdd33dfedcb71ffeeeb42ae7f";
-        const DEFINITION: &'static str = r#"# This message is used by the PointCloud message to hold optional data
+        const DEFINITION: &'static str = r####"# This message is used by the PointCloud message to hold optional data
 # associated with each point in the cloud. The length of the values
 # array should be the same as the length of the points array in the
 # PointCloud, and each value should be associated with the corresponding
@@ -7564,7 +7564,7 @@ string name
 
 # The values array should be 1-1 with the elements of the associated
 # PointCloud.
-float32[] values"#;
+float32[] values"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7585,7 +7585,7 @@ float32[] values"#;
     impl ::roslibrust::RosMessageType for CompressedImage {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CompressedImage";
         const MD5SUM: &'static str = "8f7a12909da2c9d3332d540a0977563f";
-        const DEFINITION: &'static str = r#"# This message contains a compressed image
+        const DEFINITION: &'static str = r####"# This message contains a compressed image
 
 Header header        # Header timestamp should be acquisition time of image
                      # Header frame_id should be optical frame of camera
@@ -7612,7 +7612,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7632,7 +7632,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for FluidPressure {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/FluidPressure";
         const MD5SUM: &'static str = "804dc5cea1c5306d6a2eb80b9833befe";
-        const DEFINITION: &'static str = r#"# Single pressure reading.  This message is appropriate for measuring the
+        const DEFINITION: &'static str = r####"# Single pressure reading.  This message is appropriate for measuring the
  # pressure inside of a fluid (air, water, etc).  This also includes
  # atmospheric or barometric pressure.
 
@@ -7658,7 +7658,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7678,7 +7678,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Illuminance {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Illuminance";
         const MD5SUM: &'static str = "8cf5febb0952fca9d650c3d11a81a188";
-        const DEFINITION: &'static str = r#"# Single photometric illuminance measurement.  Light should be assumed to be
+        const DEFINITION: &'static str = r####"# Single photometric illuminance measurement.  Light should be assumed to be
  # measured along the sensor's x-axis (the area of detection is the y-z plane).
  # The illuminance should have a 0 or positive value and be received with
  # the sensor's +X axis pointing toward the light source.
@@ -7713,7 +7713,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7738,7 +7738,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Image {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Image";
         const MD5SUM: &'static str = "060021388200f6f0f447d0fcd9c64743";
-        const DEFINITION: &'static str = r#"# This message contains an uncompressed image
+        const DEFINITION: &'static str = r####"# This message contains an uncompressed image
 # (0, 0) is at top-left corner of image
 #
 
@@ -7779,7 +7779,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7803,7 +7803,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
         const MD5SUM: &'static str = "6a62c6daae103f4ff57a132d6f95cec2";
-        const DEFINITION: &'static str = r#"# This is a message to hold data from an IMU (Inertial Measurement Unit)
+        const DEFINITION: &'static str = r####"# This is a message to hold data from an IMU (Inertial Measurement Unit)
 #
 # Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec
 #
@@ -7861,7 +7861,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7883,7 +7883,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for JointState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JointState";
         const MD5SUM: &'static str = "3066dcd76a6cfaef579bd0f34173e9fd";
-        const DEFINITION: &'static str = r#"# This is a message that holds data to describe the state of a set of torque controlled joints. 
+        const DEFINITION: &'static str = r####"# This is a message that holds data to describe the state of a set of torque controlled joints. 
 #
 # The state of each joint (revolute or prismatic) is defined by:
 #  * the position of the joint (rad or m),
@@ -7923,7 +7923,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7943,7 +7943,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Joy {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Joy";
         const MD5SUM: &'static str = "5a9ea5f83505693b71e785041e67a8bb";
-        const DEFINITION: &'static str = r#"# Reports the state of a joysticks axes and buttons.
+        const DEFINITION: &'static str = r####"# Reports the state of a joysticks axes and buttons.
 Header header           # timestamp in the header is the time the data is received from the joystick
 float32[] axes          # the axes measurements from a joystick
 int32[] buttons         # the buttons measurements from a joystick
@@ -7961,7 +7961,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7981,7 +7981,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for JoyFeedback {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JoyFeedback";
         const MD5SUM: &'static str = "f4dcd73460360d98f36e55ee7f2e46f1";
-        const DEFINITION: &'static str = r#"# Declare of the type of feedback
+        const DEFINITION: &'static str = r####"# Declare of the type of feedback
 uint8 TYPE_LED    = 0
 uint8 TYPE_RUMBLE = 1
 uint8 TYPE_BUZZER = 2
@@ -7994,7 +7994,7 @@ uint8 id
 
 # Intensity of the feedback, from 0.0 to 1.0, inclusive.  If device is
 # actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.
-float32 intensity"#;
+float32 intensity"####;
     }
     #[allow(unused)]
     impl JoyFeedback {
@@ -8018,7 +8018,7 @@ float32 intensity"#;
     impl ::roslibrust::RosMessageType for JoyFeedbackArray {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JoyFeedbackArray";
         const MD5SUM: &'static str = "cde5730a895b1fc4dee6f91b754b213d";
-        const DEFINITION: &'static str = r#"# This message publishes values for multiple feedback at once. 
+        const DEFINITION: &'static str = r####"# This message publishes values for multiple feedback at once. 
 JoyFeedback[] array
 ================================================================================
 MSG: sensor_msgs/JoyFeedback
@@ -8035,7 +8035,7 @@ uint8 id
 
 # Intensity of the feedback, from 0.0 to 1.0, inclusive.  If device is
 # actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.
-float32 intensity"#;
+float32 intensity"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8053,11 +8053,11 @@ float32 intensity"#;
     impl ::roslibrust::RosMessageType for LaserEcho {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/LaserEcho";
         const MD5SUM: &'static str = "8bc5ae449b200fba4d552b4225586696";
-        const DEFINITION: &'static str = r#"# This message is a submessage of MultiEchoLaserScan and is not intended
+        const DEFINITION: &'static str = r####"# This message is a submessage of MultiEchoLaserScan and is not intended
 # to be used separately.
 
 float32[] echoes  # Multiple values of ranges or intensities.
-                  # Each array represents data from the same angle increment."#;
+                  # Each array represents data from the same angle increment."####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8084,7 +8084,7 @@ float32[] echoes  # Multiple values of ranges or intensities.
     impl ::roslibrust::RosMessageType for LaserScan {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/LaserScan";
         const MD5SUM: &'static str = "90c7ef2dc6895d81024acba2ac42f369";
-        const DEFINITION: &'static str = r#"# Single scan from a planar laser range-finder
+        const DEFINITION: &'static str = r####"# Single scan from a planar laser range-finder
 #
 # If you have another ranging device with different behavior (e.g. a sonar
 # array), please find or create a different message, since applications
@@ -8127,7 +8127,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8147,7 +8147,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
         const MD5SUM: &'static str = "2f3b0b43eed0c9501de0fa3ff89a45aa";
-        const DEFINITION: &'static str = r#"# Measurement of the Magnetic Field vector at a specific location.
+        const DEFINITION: &'static str = r####"# Measurement of the Magnetic Field vector at a specific location.
 
  # If the covariance of the measurement is known, it should be filled in
  # (if all you know is the variance of each measurement, e.g. from the datasheet,
@@ -8195,7 +8195,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8217,7 +8217,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MultiDOFJointState";
         const MD5SUM: &'static str = "690f272f0640d2631c305eeb8301e59d";
-        const DEFINITION: &'static str = r#"# Representation of state for joints with multiple degrees of freedom, 
+        const DEFINITION: &'static str = r####"# Representation of state for joints with multiple degrees of freedom, 
 # following the structure of JointState.
 #
 # It is assumed that a joint in a system corresponds to a transform that gets applied 
@@ -8338,7 +8338,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8365,7 +8365,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MultiEchoLaserScan {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MultiEchoLaserScan";
         const MD5SUM: &'static str = "6fefb0c6da89d7c8abe4b339f5c2f8fb";
-        const DEFINITION: &'static str = r#"# Single scan from a multi-echo planar laser range-finder
+        const DEFINITION: &'static str = r####"# Single scan from a multi-echo planar laser range-finder
 #
 # If you have another ranging device with different behavior (e.g. a sonar
 # array), please find or create a different message, since applications
@@ -8417,7 +8417,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8441,7 +8441,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for NavSatFix {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatFix";
         const MD5SUM: &'static str = "2d3a8cd499b9b4a0249fb98fd05cfa48";
-        const DEFINITION: &'static str = r#"# Navigation Satellite fix for any Global Navigation Satellite System
+        const DEFINITION: &'static str = r####"# Navigation Satellite fix for any Global Navigation Satellite System
 #
 # Specified using the WGS 84 reference ellipsoid
 
@@ -8525,7 +8525,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl NavSatFix {
@@ -8551,7 +8551,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for NavSatStatus {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatStatus";
         const MD5SUM: &'static str = "331cdbddfa4bc96ffc3b9ad98900a54c";
-        const DEFINITION: &'static str = r#"# Navigation Satellite fix status for any Global Navigation Satellite System
+        const DEFINITION: &'static str = r####"# Navigation Satellite fix status for any Global Navigation Satellite System
 
 # Whether to output an augmented fix is determined by both the fix
 # type and the last time differential corrections were received.  A
@@ -8572,7 +8572,7 @@ uint16 SERVICE_GLONASS = 2
 uint16 SERVICE_COMPASS = 4      # includes BeiDou.
 uint16 SERVICE_GALILEO = 8
 
-uint16 service"#;
+uint16 service"####;
     }
     #[allow(unused)]
     impl NavSatStatus {
@@ -8603,7 +8603,7 @@ uint16 service"#;
     impl ::roslibrust::RosMessageType for PointCloud {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointCloud";
         const MD5SUM: &'static str = "d8e9c3f5afbdd8a130fd1d2763945fca";
-        const DEFINITION: &'static str = r#"# This message holds a collection of 3d points, plus optional additional
+        const DEFINITION: &'static str = r####"# This message holds a collection of 3d points, plus optional additional
 # information about each point.
 
 # Time of sensor data acquisition, coordinate frame ID.
@@ -8670,7 +8670,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8697,7 +8697,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PointCloud2 {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointCloud2";
         const MD5SUM: &'static str = "1158d486dd51d683ce2f1be655c3c181";
-        const DEFINITION: &'static str = r#"# This message holds a collection of N-dimensional points, which may
+        const DEFINITION: &'static str = r####"# This message holds a collection of N-dimensional points, which may
 # contain additional information such as normals, intensity, etc. The
 # point data is stored as a binary blob, its layout described by the
 # contents of the "fields" array.
@@ -8755,7 +8755,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8776,7 +8776,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PointField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointField";
         const MD5SUM: &'static str = "268eacb2962780ceac86cbd17e328150";
-        const DEFINITION: &'static str = r#"# This message holds the description of one point entry in the
+        const DEFINITION: &'static str = r####"# This message holds the description of one point entry in the
 # PointCloud2 message format.
 uint8 INT8    = 1
 uint8 UINT8   = 2
@@ -8790,7 +8790,7 @@ uint8 FLOAT64 = 8
 string name      # Name of field
 uint32 offset    # Offset from start of point struct
 uint8  datatype  # Datatype enumeration, see above
-uint32 count     # How many elements in the field"#;
+uint32 count     # How many elements in the field"####;
     }
     #[allow(unused)]
     impl PointField {
@@ -8824,7 +8824,7 @@ uint32 count     # How many elements in the field"#;
     impl ::roslibrust::RosMessageType for Range {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Range";
         const MD5SUM: &'static str = "c005c34273dc426c67a020a87bc24148";
-        const DEFINITION: &'static str = r#"# Single range reading from an active ranger that emits energy and reports
+        const DEFINITION: &'static str = r####"# Single range reading from an active ranger that emits energy and reports
 # one range reading that is valid along an arc at the distance measured. 
 # This message is  not appropriate for laser scanners. See the LaserScan
 # message if you are working with a laser scanner.
@@ -8878,7 +8878,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl Range {
@@ -8905,7 +8905,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for RegionOfInterest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/RegionOfInterest";
         const MD5SUM: &'static str = "bdb633039d588fcccb441a4d43ccfe09";
-        const DEFINITION: &'static str = r#"# This message is used to specify a region of interest within an image.
+        const DEFINITION: &'static str = r####"# This message is used to specify a region of interest within an image.
 #
 # When used to specify the ROI setting of the camera when the image was
 # taken, the height and width fields should either match the height and
@@ -8923,7 +8923,7 @@ uint32 width     # Width of ROI
 # ROI in this message. Typically this should be False if the full image
 # is captured (ROI not used), and True if a subwindow is captured (ROI
 # used).
-bool do_rectify"#;
+bool do_rectify"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8943,7 +8943,7 @@ bool do_rectify"#;
     impl ::roslibrust::RosMessageType for RelativeHumidity {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/RelativeHumidity";
         const MD5SUM: &'static str = "8730015b05955b7e992ce29a2678d90f";
-        const DEFINITION: &'static str = r#"# Single reading from a relative humidity sensor.  Defines the ratio of partial
+        const DEFINITION: &'static str = r####"# Single reading from a relative humidity sensor.  Defines the ratio of partial
  # pressure of water vapor to the saturated vapor pressure at a temperature.
 
  Header header             # timestamp of the measurement
@@ -8969,7 +8969,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8989,7 +8989,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Temperature {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Temperature";
         const MD5SUM: &'static str = "ff71b307acdbe7c871a5a6d7ed359100";
-        const DEFINITION: &'static str = r#"# Single temperature reading.
+        const DEFINITION: &'static str = r####"# Single temperature reading.
 
  Header header           # timestamp is the time the temperature was measured
                          # frame_id is the location of the temperature reading
@@ -9011,7 +9011,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9031,7 +9031,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for TimeReference {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/TimeReference";
         const MD5SUM: &'static str = "fded64a0265108ba86c3d38fb11c0c16";
-        const DEFINITION: &'static str = r#"# Measurement from an external time source not actively synchronized with the system clock.
+        const DEFINITION: &'static str = r####"# Measurement from an external time source not actively synchronized with the system clock.
 
 Header header    # stamp is system time for which measurement was valid
                  # frame_id is not used 
@@ -9052,7 +9052,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9070,7 +9070,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetCameraInfoRequest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoRequest";
         const MD5SUM: &'static str = "ee34be01fdeee563d0d99cd594d5581d";
-        const DEFINITION: &'static str = r#"# This service requests that a camera stores the given CameraInfo 
+        const DEFINITION: &'static str = r####"# This service requests that a camera stores the given CameraInfo 
 # as that camera's calibration information.
 #
 # The width and height in the camera_info field should match what the
@@ -9283,7 +9283,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9302,8 +9302,8 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetCameraInfoResponse {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoResponse";
         const MD5SUM: &'static str = "2ec6f3eff0161f4257b808b12bc830c2";
-        const DEFINITION: &'static str = r#"bool success          # True if the call succeeded
-string status_message # Used to give details about success"#;
+        const DEFINITION: &'static str = r####"bool success          # True if the call succeeded
+string status_message # Used to give details about success"####;
     }
     #[allow(dead_code)]
     pub struct SetCameraInfo {}
@@ -9346,7 +9346,7 @@ pub mod shape_msgs {
     impl ::roslibrust::RosMessageType for Mesh {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Mesh";
         const MD5SUM: &'static str = "1ffdae9486cd3316a121c578b47a85cc";
-        const DEFINITION: &'static str = r#"# Definition of a mesh
+        const DEFINITION: &'static str = r####"# Definition of a mesh
 
 # list of triangles; the index values refer to positions in vertices[]
 MeshTriangle[] triangles
@@ -9362,7 +9362,7 @@ float64 z
 ================================================================================
 MSG: shape_msgs/MeshTriangle
 # Definition of a triangle's vertices
-uint32[3] vertex_indices"#;
+uint32[3] vertex_indices"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9380,8 +9380,8 @@ uint32[3] vertex_indices"#;
     impl ::roslibrust::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
         const MD5SUM: &'static str = "23688b2e6d2de3d32fe8af104a903253";
-        const DEFINITION: &'static str = r#"# Definition of a triangle's vertices
-uint32[3] vertex_indices"#;
+        const DEFINITION: &'static str = r####"# Definition of a triangle's vertices
+uint32[3] vertex_indices"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9399,14 +9399,14 @@ uint32[3] vertex_indices"#;
     impl ::roslibrust::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";
         const MD5SUM: &'static str = "2c1b92ed8f31492f8e73f6a4a44ca796";
-        const DEFINITION: &'static str = r#"# Representation of a plane, using the plane equation ax + by + cz + d = 0
+        const DEFINITION: &'static str = r####"# Representation of a plane, using the plane equation ax + by + cz + d = 0
 
 # a := coef[0]
 # b := coef[1]
 # c := coef[2]
 # d := coef[3]
 
-float64[4] coef"#;
+float64[4] coef"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9425,7 +9425,7 @@ float64[4] coef"#;
     impl ::roslibrust::RosMessageType for SolidPrimitive {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/SolidPrimitive";
         const MD5SUM: &'static str = "d8f8cbc74c5ff283fca29569ccefb45d";
-        const DEFINITION: &'static str = r#"# Define box, sphere, cylinder, cone 
+        const DEFINITION: &'static str = r####"# Define box, sphere, cylinder, cone 
 # All shapes are defined to have their bounding boxes centered around 0,0,0.
 
 uint8 BOX=1
@@ -9466,7 +9466,7 @@ uint8 CYLINDER_HEIGHT=0
 uint8 CYLINDER_RADIUS=1
 
 uint8 CONE_HEIGHT=0
-uint8 CONE_RADIUS=1"#;
+uint8 CONE_RADIUS=1"####;
     }
     #[allow(unused)]
     impl SolidPrimitive {
@@ -9515,7 +9515,7 @@ pub mod std_msgs {
     impl ::roslibrust::RosMessageType for Bool {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Bool";
         const MD5SUM: &'static str = "8b94c1b53db61fb6aed406028ad6332a";
-        const DEFINITION: &'static str = r#"bool data"#;
+        const DEFINITION: &'static str = r####"bool data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9533,7 +9533,7 @@ pub mod std_msgs {
     impl ::roslibrust::RosMessageType for Byte {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Byte";
         const MD5SUM: &'static str = "ad736a2e8818154c487bb80fe42ce43b";
-        const DEFINITION: &'static str = r#"byte data"#;
+        const DEFINITION: &'static str = r####"byte data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9552,7 +9552,7 @@ pub mod std_msgs {
     impl ::roslibrust::RosMessageType for ByteMultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/ByteMultiArray";
         const MD5SUM: &'static str = "70ea476cbcfd65ac2f68f3cda1e891fe";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -9594,7 +9594,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9612,7 +9612,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Char {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Char";
         const MD5SUM: &'static str = "1bf77f25acecdedba0e224b162199717";
-        const DEFINITION: &'static str = r#"char data"#;
+        const DEFINITION: &'static str = r####"char data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9633,10 +9633,10 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for ColorRGBA {
         const ROS_TYPE_NAME: &'static str = "std_msgs/ColorRGBA";
         const MD5SUM: &'static str = "a29a96539573343b1310c73607334b00";
-        const DEFINITION: &'static str = r#"float32 r
+        const DEFINITION: &'static str = r####"float32 r
 float32 g
 float32 b
-float32 a"#;
+float32 a"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9654,7 +9654,7 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Duration {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Duration";
         const MD5SUM: &'static str = "3e286caf4241d664e55f3ad380e2ae46";
-        const DEFINITION: &'static str = r#"duration data"#;
+        const DEFINITION: &'static str = r####"duration data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9670,7 +9670,7 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Empty {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Empty";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9688,7 +9688,7 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Float32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float32";
         const MD5SUM: &'static str = "73fcbf46b49191e672908e50842a83d4";
-        const DEFINITION: &'static str = r#"float32 data"#;
+        const DEFINITION: &'static str = r####"float32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9707,7 +9707,7 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Float32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float32MultiArray";
         const MD5SUM: &'static str = "6a40e0ffa6a17a503ac3f8616991b1f6";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -9749,7 +9749,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9767,7 +9767,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Float64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float64";
         const MD5SUM: &'static str = "fdb28210bfa9d7c91146260178d9a584";
-        const DEFINITION: &'static str = r#"float64 data"#;
+        const DEFINITION: &'static str = r####"float64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9786,7 +9786,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Float64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float64MultiArray";
         const MD5SUM: &'static str = "4b7d974086d4060e7db4613a7e6c3ba4";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -9828,7 +9828,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9848,7 +9848,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Header {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Header";
         const MD5SUM: &'static str = "2176decaecbce78abc3b96ef049fabed";
-        const DEFINITION: &'static str = r#"# Standard metadata for higher-level stamped data types.
+        const DEFINITION: &'static str = r####"# Standard metadata for higher-level stamped data types.
 # This is generally used to communicate timestamped data 
 # in a particular coordinate frame.
 # 
@@ -9860,7 +9860,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9878,7 +9878,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Int16 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int16";
         const MD5SUM: &'static str = "8524586e34fbd7cb1c08c5f5f1ca0e57";
-        const DEFINITION: &'static str = r#"int16 data"#;
+        const DEFINITION: &'static str = r####"int16 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9897,7 +9897,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Int16MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int16MultiArray";
         const MD5SUM: &'static str = "d9338d7f523fcb692fae9d0a0e9f067c";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -9939,7 +9939,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9957,7 +9957,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int32";
         const MD5SUM: &'static str = "da5909fbe378aeaf85e547e830cc1bb7";
-        const DEFINITION: &'static str = r#"int32 data"#;
+        const DEFINITION: &'static str = r####"int32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9976,7 +9976,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int32MultiArray";
         const MD5SUM: &'static str = "1d99f79f8b325b44fee908053e9c945b";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10018,7 +10018,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10036,7 +10036,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int64";
         const MD5SUM: &'static str = "34add168574510e6e17f5d23ecc077ef";
-        const DEFINITION: &'static str = r#"int64 data"#;
+        const DEFINITION: &'static str = r####"int64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10055,7 +10055,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int64MultiArray";
         const MD5SUM: &'static str = "54865aa6c65be0448113a2afc6a49270";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10097,7 +10097,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10115,7 +10115,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int8 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int8";
         const MD5SUM: &'static str = "27ffa0c9c4b8fb8492252bcad9e5c57b";
-        const DEFINITION: &'static str = r#"int8 data"#;
+        const DEFINITION: &'static str = r####"int8 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10134,7 +10134,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int8MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int8MultiArray";
         const MD5SUM: &'static str = "d7c1af35a1b4781bbe79e03dd94b7c13";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10176,7 +10176,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10196,9 +10196,9 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for MultiArrayDimension {
         const ROS_TYPE_NAME: &'static str = "std_msgs/MultiArrayDimension";
         const MD5SUM: &'static str = "4cd0c83a8683deae40ecdac60e53bfa8";
-        const DEFINITION: &'static str = r#"string label   # label of given dimension
+        const DEFINITION: &'static str = r####"string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10217,7 +10217,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for MultiArrayLayout {
         const ROS_TYPE_NAME: &'static str = "std_msgs/MultiArrayLayout";
         const MD5SUM: &'static str = "0fed2a11c13e11c5571b4e2a995a91a3";
-        const DEFINITION: &'static str = r#"# The multiarray declares a generic multi-dimensional array of a
+        const DEFINITION: &'static str = r####"# The multiarray declares a generic multi-dimensional array of a
 # particular data type.  Dimensions are ordered from outer most
 # to inner most.
 
@@ -10247,7 +10247,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10265,7 +10265,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for String {
         const ROS_TYPE_NAME: &'static str = "std_msgs/String";
         const MD5SUM: &'static str = "992ce8a1687cec8c8bd883ec73ca41d1";
-        const DEFINITION: &'static str = r#"string data"#;
+        const DEFINITION: &'static str = r####"string data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10283,7 +10283,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Time {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Time";
         const MD5SUM: &'static str = "cd7166c74c552c311fbcc2fe5a7bc289";
-        const DEFINITION: &'static str = r#"time data"#;
+        const DEFINITION: &'static str = r####"time data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10301,7 +10301,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt16 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt16";
         const MD5SUM: &'static str = "1df79edf208b629fe6b81923a544552d";
-        const DEFINITION: &'static str = r#"uint16 data"#;
+        const DEFINITION: &'static str = r####"uint16 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10320,7 +10320,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt16MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt16MultiArray";
         const MD5SUM: &'static str = "52f264f1c973c4b73790d384c6cb4484";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10362,7 +10362,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10380,7 +10380,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt32";
         const MD5SUM: &'static str = "304a39449588c7f8ce2df6e8001c5fce";
-        const DEFINITION: &'static str = r#"uint32 data"#;
+        const DEFINITION: &'static str = r####"uint32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10399,7 +10399,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt32MultiArray";
         const MD5SUM: &'static str = "4d6a180abc9be191b96a7eda6c8a233d";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10441,7 +10441,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10459,7 +10459,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt64";
         const MD5SUM: &'static str = "1b2a79973e8bf53d7b53acb71299cb57";
-        const DEFINITION: &'static str = r#"uint64 data"#;
+        const DEFINITION: &'static str = r####"uint64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10478,7 +10478,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt64MultiArray";
         const MD5SUM: &'static str = "6088f127afb1d6c72927aa1247e945af";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10520,7 +10520,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10538,7 +10538,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt8 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt8";
         const MD5SUM: &'static str = "7c8164229e7d2c17eb95e9231617fdee";
-        const DEFINITION: &'static str = r#"uint8 data"#;
+        const DEFINITION: &'static str = r####"uint8 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10558,7 +10558,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt8MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt8MultiArray";
         const MD5SUM: &'static str = "82373f1612381bb6ee473b5cd6f5d89c";
-        const DEFINITION: &'static str = r#"# Please look at the MultiArrayLayout message definition for
+        const DEFINITION: &'static str = r####"# Please look at the MultiArrayLayout message definition for
 # documentation on all multiarrays.
 
 MultiArrayLayout  layout        # specification of data layout
@@ -10600,7 +10600,7 @@ uint32 data_offset        # padding elements at front of data
 MSG: std_msgs/MultiArrayDimension
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
 }
 #[allow(unused_imports)]
@@ -10632,7 +10632,7 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for EmptyRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/EmptyRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10648,7 +10648,7 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for EmptyResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/EmptyResponse";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(dead_code)]
     pub struct Empty {}
@@ -10674,7 +10674,8 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for SetBoolRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/SetBoolRequest";
         const MD5SUM: &'static str = "8b94c1b53db61fb6aed406028ad6332a";
-        const DEFINITION: &'static str = r#"bool data # e.g. for hardware enabling / disabling"#;
+        const DEFINITION: &'static str =
+            r####"bool data # e.g. for hardware enabling / disabling"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10693,8 +10694,8 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for SetBoolResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/SetBoolResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"bool success   # indicate successful run of triggered service
-string message # informational, e.g. for error messages"#;
+        const DEFINITION: &'static str = r####"bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages"####;
     }
     #[allow(dead_code)]
     pub struct SetBool {}
@@ -10718,7 +10719,7 @@ string message # informational, e.g. for error messages"#;
     impl ::roslibrust::RosMessageType for TriggerRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/TriggerRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10737,8 +10738,8 @@ string message # informational, e.g. for error messages"#;
     impl ::roslibrust::RosMessageType for TriggerResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/TriggerResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"bool success   # indicate successful run of triggered service
-string message # informational, e.g. for error messages"#;
+        const DEFINITION: &'static str = r####"bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages"####;
     }
     #[allow(dead_code)]
     pub struct Trigger {}
@@ -10787,7 +10788,7 @@ pub mod stereo_msgs {
     impl ::roslibrust::RosMessageType for DisparityImage {
         const ROS_TYPE_NAME: &'static str = "stereo_msgs/DisparityImage";
         const MD5SUM: &'static str = "04a177815f75271039fa21f16acad8c9";
-        const DEFINITION: &'static str = r#"# Separate header for compatibility with current TimeSynchronizer.
+        const DEFINITION: &'static str = r####"# Separate header for compatibility with current TimeSynchronizer.
 # Likely to be removed in a later release, use image.header instead.
 Header header
 
@@ -10895,7 +10896,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -10927,12 +10928,12 @@ pub mod test_msgs {
     impl ::roslibrust::RosMessageType for Constants {
         const ROS_TYPE_NAME: &'static str = "test_msgs/Constants";
         const MD5SUM: &'static str = "027df5f26b72c57b1e40902038ca3eec";
-        const DEFINITION: &'static str = r#"string TEST_STR="/topic"
+        const DEFINITION: &'static str = r####"string TEST_STR="/topic"
 string TEST_STR_2 = '/topic_2'
 # Apparently unquoted strings are also valid?
 # Pulled from https://github.com/ros/bond_core/blob/kinetic-devel/bond/msg/Constants.msg
 string DISABLE_HEARTBEAT_TIMEOUT_PARAM=/bond_disable_heartbeat_timeout
-float32 TEST_FLOAT=0 # testing"#;
+float32 TEST_FLOAT=0 # testing"####;
     }
     #[allow(unused)]
     impl Constants {
@@ -10959,7 +10960,7 @@ float32 TEST_FLOAT=0 # testing"#;
     impl ::roslibrust::RosMessageType for Float64Stamped {
         const ROS_TYPE_NAME: &'static str = "test_msgs/Float64Stamped";
         const MD5SUM: &'static str = "d053817de0764f9ee90dbc89c4cdd751";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 float64 value
 ================================================================================
 MSG: std_msgs/Header
@@ -10975,7 +10976,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -10993,7 +10994,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for LoggerLevel {
         const ROS_TYPE_NAME: &'static str = "test_msgs/LoggerLevel";
         const MD5SUM: &'static str = "097b0e938d0dd7788057f4cdc9013238";
-        const DEFINITION: &'static str = r#"string level"#;
+        const DEFINITION: &'static str = r####"string level"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11013,7 +11014,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Metric {
         const ROS_TYPE_NAME: &'static str = "test_msgs/Metric";
         const MD5SUM: &'static str = "474be567370f515a7d5d3f3243aad369";
-        const DEFINITION: &'static str = r#"#Metric data type
+        const DEFINITION: &'static str = r####"#Metric data type
 #For logging a set of points, e.g. for a pie chart
 
 string name
@@ -11024,7 +11025,7 @@ MSG: test_msgs/MetricPair
 #Data type for storing the key/value pairs from the Metric.data map
 
 string key
-float64 value"#;
+float64 value"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11043,10 +11044,10 @@ float64 value"#;
     impl ::roslibrust::RosMessageType for MetricPair {
         const ROS_TYPE_NAME: &'static str = "test_msgs/MetricPair";
         const MD5SUM: &'static str = "a681f679e1c39fbe570b7737e7cf183d";
-        const DEFINITION: &'static str = r#"#Data type for storing the key/value pairs from the Metric.data map
+        const DEFINITION: &'static str = r####"#Data type for storing the key/value pairs from the Metric.data map
 
 string key
-float64 value"#;
+float64 value"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11066,7 +11067,7 @@ float64 value"#;
     impl ::roslibrust::RosMessageType for NodeInfo {
         const ROS_TYPE_NAME: &'static str = "test_msgs/NodeInfo";
         const MD5SUM: &'static str = "7fab1acc377fd48898b00b7f3a897f47";
-        const DEFINITION: &'static str = r#"string node_name
+        const DEFINITION: &'static str = r####"string node_name
 int64 pid
 
 # Node is created, but is not yet initialized.
@@ -11081,7 +11082,7 @@ uint8 STATUS_RUN_ERROR=3
 uint8 STATUS_SHUTTING_DOWN=4
 # Node is stopped.
 uint8 STATUS_SHUTDOWN=5
-uint8 status"#;
+uint8 status"####;
     }
     #[allow(unused)]
     impl NodeInfo {
@@ -11109,11 +11110,11 @@ uint8 status"#;
     impl ::roslibrust::RosMessageType for AddTwoIntsRequest {
         const ROS_TYPE_NAME: &'static str = "test_msgs/AddTwoIntsRequest";
         const MD5SUM: &'static str = "36d09b846be0b371c5f190354dd3153e";
-        const DEFINITION: &'static str = r#"# AddTwoInts.srv
+        const DEFINITION: &'static str = r####"# AddTwoInts.srv
 # --- for funsies
 # From this ROS tutorial: http://wiki.ros.org/ROS/Tutorials/CreatingMsgAndSrv#Creating_a_srv
 int64 a
-int64 b"#;
+int64 b"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11131,8 +11132,8 @@ int64 b"#;
     impl ::roslibrust::RosMessageType for AddTwoIntsResponse {
         const ROS_TYPE_NAME: &'static str = "test_msgs/AddTwoIntsResponse";
         const MD5SUM: &'static str = "b88405221c77b1878a3cbbfff53428d7";
-        const DEFINITION: &'static str = r#"# Overflow? What overflow?
-int64 sum"#;
+        const DEFINITION: &'static str = r####"# Overflow? What overflow?
+int64 sum"####;
     }
     #[allow(dead_code)]
     pub struct AddTwoInts {}
@@ -11159,8 +11160,8 @@ int64 sum"#;
     impl ::roslibrust::RosMessageType for RoundTripArrayRequest {
         const ROS_TYPE_NAME: &'static str = "test_msgs/RoundTripArrayRequest";
         const MD5SUM: &'static str = "d159f2bd8169d3b3339e6f1fce045c6d";
-        const DEFINITION: &'static str = r#"# Purpose of this array is send and receive a large payload 
-uint8[] bytes"#;
+        const DEFINITION: &'static str = r####"# Purpose of this array is send and receive a large payload 
+uint8[] bytes"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11179,7 +11180,7 @@ uint8[] bytes"#;
     impl ::roslibrust::RosMessageType for RoundTripArrayResponse {
         const ROS_TYPE_NAME: &'static str = "test_msgs/RoundTripArrayResponse";
         const MD5SUM: &'static str = "d159f2bd8169d3b3339e6f1fce045c6d";
-        const DEFINITION: &'static str = r#"uint8[] bytes"#;
+        const DEFINITION: &'static str = r####"uint8[] bytes"####;
     }
     #[allow(dead_code)]
     pub struct RoundTripArray {}
@@ -11223,7 +11224,7 @@ pub mod trajectory_msgs {
     impl ::roslibrust::RosMessageType for JointTrajectory {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/JointTrajectory";
         const MD5SUM: &'static str = "65b4f94a94d1ed67169da35a02f33d3f";
-        const DEFINITION: &'static str = r#"Header header
+        const DEFINITION: &'static str = r####"Header header
 string[] joint_names
 JointTrajectoryPoint[] points
 ================================================================================
@@ -11251,7 +11252,7 @@ float64[] positions
 float64[] velocities
 float64[] accelerations
 float64[] effort
-duration time_from_start"#;
+duration time_from_start"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11273,7 +11274,7 @@ duration time_from_start"#;
     impl ::roslibrust::RosMessageType for JointTrajectoryPoint {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/JointTrajectoryPoint";
         const MD5SUM: &'static str = "f3cd1e1c4d320c79d6985c904ae5dcd3";
-        const DEFINITION: &'static str = r#"# Each trajectory point specifies either positions[, velocities[, accelerations]]
+        const DEFINITION: &'static str = r####"# Each trajectory point specifies either positions[, velocities[, accelerations]]
 # or positions[, effort] for the trajectory to be executed.
 # All specified values are in the same order as the joint names in JointTrajectory.msg
 
@@ -11281,7 +11282,7 @@ float64[] positions
 float64[] velocities
 float64[] accelerations
 float64[] effort
-duration time_from_start"#;
+duration time_from_start"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11301,7 +11302,7 @@ duration time_from_start"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointTrajectory {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/MultiDOFJointTrajectory";
         const MD5SUM: &'static str = "ef145a45a5f47b77b7f5cdde4b16c942";
-        const DEFINITION: &'static str = r#"# The header is used to specify the coordinate frame and the reference time for the trajectory durations
+        const DEFINITION: &'static str = r####"# The header is used to specify the coordinate frame and the reference time for the trajectory durations
 Header header
 
 # A representation of a multi-dof joint trajectory (each point is a transformation)
@@ -11463,7 +11464,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11484,7 +11485,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointTrajectoryPoint {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/MultiDOFJointTrajectoryPoint";
         const MD5SUM: &'static str = "3ebe08d1abd5b65862d50e09430db776";
-        const DEFINITION: &'static str = r#"# Each multi-dof joint can specify a transform (up to 6 DOF)
+        const DEFINITION: &'static str = r####"# Each multi-dof joint can specify a transform (up to 6 DOF)
 geometry_msgs/Transform[] transforms
 
 # There can be a velocity specified for the origin of the joint 
@@ -11556,7 +11557,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
 }
 #[allow(unused_imports)]
@@ -11602,7 +11603,7 @@ pub mod visualization_msgs {
     impl ::roslibrust::RosMessageType for ImageMarker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/ImageMarker";
         const MD5SUM: &'static str = "1de93c67ec8858b831025a08fbf1b35c";
-        const DEFINITION: &'static str = r#"uint8 CIRCLE=0
+        const DEFINITION: &'static str = r####"uint8 CIRCLE=0
 uint8 LINE_STRIP=1
 uint8 LINE_LIST=2
 uint8 POLYGON=3
@@ -11652,7 +11653,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl ImageMarker {
@@ -11686,7 +11687,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarker";
         const MD5SUM: &'static str = "dd86d22909d5a3364b384492e35c10af";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 # If header.time is set to 0, the marker will be retransformed into
 # its frame on each timestep. You will receive the pose feedback
 # in the same frame.
@@ -12202,7 +12203,7 @@ string command
 uint8 FEEDBACK=0
 uint8 ROSRUN=1
 uint8 ROSLAUNCH=2
-uint8 command_type"#;
+uint8 command_type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -12227,7 +12228,7 @@ uint8 command_type"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerControl {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerControl";
         const MD5SUM: &'static str = "b3c81e785788195d1840b86c28da1aac";
-        const DEFINITION: &'static str = r#"# Represents a control that is to be displayed together with an interactive marker
+        const DEFINITION: &'static str = r####"# Represents a control that is to be displayed together with an interactive marker
 
 # Identifying string for this control.
 # You need to assign a unique value to this to receive feedback from the GUI
@@ -12481,7 +12482,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerControl {
@@ -12523,7 +12524,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerFeedback {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerFeedback";
         const MD5SUM: &'static str = "ab0f1eee058667e28c19ff3ffc3f4b78";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 Header header
 
 # Identifying string. Must be unique in the topic namespace.
@@ -12612,7 +12613,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerFeedback {
@@ -12641,7 +12642,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerInit {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerInit";
         const MD5SUM: &'static str = "d5f2c5045a72456d228676ab91048734";
-        const DEFINITION: &'static str = r#"# Identifying string. Must be unique in the topic namespace
+        const DEFINITION: &'static str = r####"# Identifying string. Must be unique in the topic namespace
 # that this server works on.
 string server_id
 
@@ -13664,7 +13665,7 @@ string command
 uint8 FEEDBACK=0
 uint8 ROSRUN=1
 uint8 ROSLAUNCH=2
-uint8 command_type"#;
+uint8 command_type"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13684,7 +13685,7 @@ uint8 command_type"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerPose {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerPose";
         const MD5SUM: &'static str = "a6e6833209a196a38d798dadb02c81f8";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 Header header
 
 # Initial pose. Also, defines the pivot point for rotations.
@@ -13740,7 +13741,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13763,7 +13764,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerUpdate {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerUpdate";
         const MD5SUM: &'static str = "710d308d0a9276d65945e92dd30b3946";
-        const DEFINITION: &'static str = r#"# Identifying string. Must be unique in the topic namespace
+        const DEFINITION: &'static str = r####"# Identifying string. Must be unique in the topic namespace
 # that this server works on.
 string server_id
 
@@ -14862,7 +14863,7 @@ string command
 uint8 FEEDBACK=0
 uint8 ROSRUN=1
 uint8 ROSLAUNCH=2
-uint8 command_type"#;
+uint8 command_type"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerUpdate {
@@ -14899,7 +14900,7 @@ uint8 command_type"#;
     impl ::roslibrust::RosMessageType for Marker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/Marker";
         const MD5SUM: &'static str = "4048c9de2a16f4ae8e0538085ebf1b97";
-        const DEFINITION: &'static str = r#"# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz
+        const DEFINITION: &'static str = r####"# See http://www.ros.org/wiki/rviz/DisplayTypes/Marker and http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes for more information on using this message with rviz
 
 uint8 ARROW=0
 uint8 CUBE=1
@@ -15008,7 +15009,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl Marker {
@@ -15045,7 +15046,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MarkerArray {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/MarkerArray";
         const MD5SUM: &'static str = "d155b9ce5188fbaf89745847fd5882d7";
-        const DEFINITION: &'static str = r#"Marker[] markers
+        const DEFINITION: &'static str = r####"Marker[] markers
 ================================================================================
 MSG: geometry_msgs/Point
 # This contains the position of a point in free space
@@ -15223,7 +15224,7 @@ uint32 seq
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -15245,7 +15246,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MenuEntry {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/MenuEntry";
         const MD5SUM: &'static str = "b90ec63024573de83b57aa93eb39be2d";
-        const DEFINITION: &'static str = r#"# MenuEntry message.
+        const DEFINITION: &'static str = r####"# MenuEntry message.
 
 # Each InteractiveMarker message has an array of MenuEntry messages.
 # A collection of MenuEntries together describe a
@@ -15298,7 +15299,7 @@ string command
 uint8 FEEDBACK=0
 uint8 ROSRUN=1
 uint8 ROSLAUNCH=2
-uint8 command_type"#;
+uint8 command_type"####;
     }
     #[allow(unused)]
     impl MenuEntry {

--- a/roslibrust_test/src/ros1.rs
+++ b/roslibrust_test/src/ros1.rs
@@ -10924,6 +10924,165 @@ pub mod test_msgs {
         PartialEq,
     )]
     #[serde(crate = "::roslibrust::codegen::serde")]
+    pub struct ADSBVehicle {
+        pub r#header: std_msgs::Header,
+        pub r#ICAO_address: u32,
+        pub r#callsign: ::std::string::String,
+        pub r#latitude: f64,
+        pub r#longitude: f64,
+        pub r#altitude: f32,
+        pub r#heading: f32,
+        pub r#hor_velocity: f32,
+        pub r#ver_velocity: f32,
+        pub r#altitude_type: u8,
+        pub r#emitter_type: u8,
+        pub r#tslc: ::roslibrust::codegen::integral_types::Duration,
+        pub r#flags: u16,
+        pub r#squawk: u16,
+    }
+    impl ::roslibrust::RosMessageType for ADSBVehicle {
+        const ROS_TYPE_NAME: &'static str = "test_msgs/ADSBVehicle";
+        const MD5SUM: &'static str = "d532685113a66fcc6ba0e6363ace0244";
+        const DEFINITION: &'static str = r####"# The location and information of an ADSB vehicle
+#
+# https://mavlink.io/en/messages/common.html#ADSB_VEHICLE
+
+# [[[cog:
+# from pymavlink.dialects.v20 import common
+#
+# def decl_enum(ename, pfx='', bsz=8):
+#     enum = sorted(common.enums[ename].items())
+#     enum.pop() # remove ENUM_END
+#
+#     cog.outl("# " + ename)
+#     for k, e in enum:
+#         sn = e.name[len(ename) + 1:]
+#         l = "uint{bsz} {pfx}{sn} = {k}".format(**locals())
+#         if e.description:
+#             l += ' ' * (40 - len(l)) + ' # ' + e.description
+#         cog.outl(l)
+#
+# decl_enum('ADSB_ALTITUDE_TYPE', 'ALT_')
+# decl_enum('ADSB_EMITTER_TYPE', 'EMITTER_')
+# decl_enum('ADSB_FLAGS', 'FLAG_', 16)
+# ]]]
+# ADSB_ALTITUDE_TYPE
+uint8 ALT_PRESSURE_QNH = 0               # Altitude reported from a Baro source using QNH reference
+uint8 ALT_GEOMETRIC = 1                  # Altitude reported from a GNSS source
+# ADSB_EMITTER_TYPE
+uint8 EMITTER_NO_INFO = 0
+uint8 EMITTER_LIGHT = 1
+uint8 EMITTER_SMALL = 2
+uint8 EMITTER_LARGE = 3
+uint8 EMITTER_HIGH_VORTEX_LARGE = 4
+uint8 EMITTER_HEAVY = 5
+uint8 EMITTER_HIGHLY_MANUV = 6
+uint8 EMITTER_ROTOCRAFT = 7
+uint8 EMITTER_UNASSIGNED = 8
+uint8 EMITTER_GLIDER = 9
+uint8 EMITTER_LIGHTER_AIR = 10
+uint8 EMITTER_PARACHUTE = 11
+uint8 EMITTER_ULTRA_LIGHT = 12
+uint8 EMITTER_UNASSIGNED2 = 13
+uint8 EMITTER_UAV = 14
+uint8 EMITTER_SPACE = 15
+uint8 EMITTER_UNASSGINED3 = 16
+uint8 EMITTER_EMERGENCY_SURFACE = 17
+uint8 EMITTER_SERVICE_SURFACE = 18
+uint8 EMITTER_POINT_OBSTACLE = 19
+# ADSB_FLAGS
+uint16 FLAG_VALID_COORDS = 1
+uint16 FLAG_VALID_ALTITUDE = 2
+uint16 FLAG_VALID_HEADING = 4
+uint16 FLAG_VALID_VELOCITY = 8
+uint16 FLAG_VALID_CALLSIGN = 16
+uint16 FLAG_VALID_SQUAWK = 32
+uint16 FLAG_SIMULATED = 64
+uint16 FLAG_VERTICAL_VELOCITY_VALID = 128
+uint16 FLAG_BARO_VALID = 256
+uint16 FLAG_SOURCE_UAT = 32768
+# [[[end]]] (checksum: a34f2a081739921b6e3e443ed0516d8d)
+
+std_msgs/Header header
+
+uint32 ICAO_address
+string callsign
+
+float64 latitude
+float64 longitude
+float32 altitude 	# AMSL
+
+float32 heading		# deg [0..360)
+float32 hor_velocity	# m/s
+float32 ver_velocity	# m/s
+
+uint8 altitude_type	# Type from ADSB_ALTITUDE_TYPE enum
+uint8 emitter_type	# Type from ADSB_EMITTER_TYPE enum
+
+duration tslc		# Duration from last communication, seconds [0..255]
+uint16 flags		# ADSB_FLAGS bit field
+uint16 squawk		# Squawk code
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id"####;
+    }
+    #[allow(unused)]
+    impl ADSBVehicle {
+        pub const r#ALT_PRESSURE_QNH: u8 = 0u8;
+        pub const r#ALT_GEOMETRIC: u8 = 1u8;
+        pub const r#EMITTER_NO_INFO: u8 = 0u8;
+        pub const r#EMITTER_LIGHT: u8 = 1u8;
+        pub const r#EMITTER_SMALL: u8 = 2u8;
+        pub const r#EMITTER_LARGE: u8 = 3u8;
+        pub const r#EMITTER_HIGH_VORTEX_LARGE: u8 = 4u8;
+        pub const r#EMITTER_HEAVY: u8 = 5u8;
+        pub const r#EMITTER_HIGHLY_MANUV: u8 = 6u8;
+        pub const r#EMITTER_ROTOCRAFT: u8 = 7u8;
+        pub const r#EMITTER_UNASSIGNED: u8 = 8u8;
+        pub const r#EMITTER_GLIDER: u8 = 9u8;
+        pub const r#EMITTER_LIGHTER_AIR: u8 = 10u8;
+        pub const r#EMITTER_PARACHUTE: u8 = 11u8;
+        pub const r#EMITTER_ULTRA_LIGHT: u8 = 12u8;
+        pub const r#EMITTER_UNASSIGNED2: u8 = 13u8;
+        pub const r#EMITTER_UAV: u8 = 14u8;
+        pub const r#EMITTER_SPACE: u8 = 15u8;
+        pub const r#EMITTER_UNASSGINED3: u8 = 16u8;
+        pub const r#EMITTER_EMERGENCY_SURFACE: u8 = 17u8;
+        pub const r#EMITTER_SERVICE_SURFACE: u8 = 18u8;
+        pub const r#EMITTER_POINT_OBSTACLE: u8 = 19u8;
+        pub const r#FLAG_VALID_COORDS: u16 = 1u16;
+        pub const r#FLAG_VALID_ALTITUDE: u16 = 2u16;
+        pub const r#FLAG_VALID_HEADING: u16 = 4u16;
+        pub const r#FLAG_VALID_VELOCITY: u16 = 8u16;
+        pub const r#FLAG_VALID_CALLSIGN: u16 = 16u16;
+        pub const r#FLAG_VALID_SQUAWK: u16 = 32u16;
+        pub const r#FLAG_SIMULATED: u16 = 64u16;
+        pub const r#FLAG_VERTICAL_VELOCITY_VALID: u16 = 128u16;
+        pub const r#FLAG_BARO_VALID: u16 = 256u16;
+        pub const r#FLAG_SOURCE_UAT: u16 = 32768u16;
+    }
+    #[allow(non_snake_case)]
+    #[derive(
+        :: roslibrust :: codegen :: Deserialize,
+        :: roslibrust :: codegen :: Serialize,
+        :: roslibrust :: codegen :: SmartDefault,
+        Debug,
+        Clone,
+        PartialEq,
+    )]
+    #[serde(crate = "::roslibrust::codegen::serde")]
     pub struct Constants {}
     impl ::roslibrust::RosMessageType for Constants {
         const ROS_TYPE_NAME: &'static str = "test_msgs/Constants";

--- a/roslibrust_test/src/ros2.rs
+++ b/roslibrust_test/src/ros2.rs
@@ -28,7 +28,7 @@ pub mod actionlib_msgs {
     impl ::roslibrust::RosMessageType for GoalID {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalID";
         const MD5SUM: &'static str = "29380925936d499346662d2ed1573d06";
-        const DEFINITION: &'static str = r#"# The stamp should store the time at which this goal was requested.
+        const DEFINITION: &'static str = r####"# The stamp should store the time at which this goal was requested.
 # It is used by an action server when it tries to preempt all
 # goals that were requested before a certain time
 builtin_interfaces/Time stamp
@@ -36,7 +36,7 @@ builtin_interfaces/Time stamp
 # The id provides a way to associate feedback and
 # result message with specific goal requests. The id
 # specified must be unique.
-string id"#;
+string id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -56,7 +56,7 @@ string id"#;
     impl ::roslibrust::RosMessageType for GoalStatus {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalStatus";
         const MD5SUM: &'static str = "c24a9e244d837a856267339807550287";
-        const DEFINITION: &'static str = r#"GoalID goal_id
+        const DEFINITION: &'static str = r####"GoalID goal_id
 uint8 status
 uint8 PENDING         = 0   # The goal has yet to be processed by the action server.
 uint8 ACTIVE          = 1   # The goal is currently being processed by the action server.
@@ -89,7 +89,7 @@ builtin_interfaces/Time stamp
 # The id provides a way to associate feedback and
 # result message with specific goal requests. The id
 # specified must be unique.
-string id"#;
+string id"####;
     }
     #[allow(unused)]
     impl GoalStatus {
@@ -121,7 +121,7 @@ string id"#;
     impl ::roslibrust::RosMessageType for GoalStatusArray {
         const ROS_TYPE_NAME: &'static str = "actionlib_msgs/GoalStatusArray";
         const MD5SUM: &'static str = "ad4c7a55992b9ff34d89596ca74a28e0";
-        const DEFINITION: &'static str = r#"# Stores the statuses for goals that are currently being tracked
+        const DEFINITION: &'static str = r####"# Stores the statuses for goals that are currently being tracked
 # by an action server
 std_msgs/Header header
 GoalStatus[] status_list
@@ -182,7 +182,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -215,7 +215,7 @@ pub mod diagnostic_msgs {
     impl ::roslibrust::RosMessageType for DiagnosticArray {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/DiagnosticArray";
         const MD5SUM: &'static str = "7f04f8332be7e46b680724aa4e9a9d71";
-        const DEFINITION: &'static str = r#"# This message is used to send diagnostic information about the state of the robot.
+        const DEFINITION: &'static str = r####"# This message is used to send diagnostic information about the state of the robot.
 std_msgs/Header header # for timestamp
 DiagnosticStatus[] status # an array of components being reported on
 ================================================================================
@@ -260,7 +260,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -282,7 +282,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for DiagnosticStatus {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/DiagnosticStatus";
         const MD5SUM: &'static str = "d0ce08bc6e5ba34c7754f563a9cabaf1";
-        const DEFINITION: &'static str = r#"# This message holds the status of an individual component of the robot.
+        const DEFINITION: &'static str = r####"# This message holds the status of an individual component of the robot.
 
 # Possible levels of operations.
 byte OK=0
@@ -305,7 +305,7 @@ MSG: diagnostic_msgs/KeyValue
 # What to label this value when viewing.
 string key
 # A value to track over time.
-string value"#;
+string value"####;
     }
     #[allow(unused)]
     impl DiagnosticStatus {
@@ -331,10 +331,10 @@ string value"#;
     impl ::roslibrust::RosMessageType for KeyValue {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/KeyValue";
         const MD5SUM: &'static str = "cf57fdc6617a881a88c16e768132149c";
-        const DEFINITION: &'static str = r#"# What to label this value when viewing.
+        const DEFINITION: &'static str = r####"# What to label this value when viewing.
 string key
 # A value to track over time.
-string value"#;
+string value"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -352,7 +352,7 @@ string value"#;
     impl ::roslibrust::RosMessageType for AddDiagnosticsRequest {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/AddDiagnosticsRequest";
         const MD5SUM: &'static str = "c26cf6e164288fbc6050d74f838bcdf0";
-        const DEFINITION: &'static str = r#"# This service is used as part of the process for loading analyzers at runtime,
+        const DEFINITION: &'static str = r####"# This service is used as part of the process for loading analyzers at runtime,
 # and should be used by a loader script or program, not as a standalone service.
 # Information about dynamic addition of analyzers can be found at
 # http://wiki.ros.org/diagnostics/Tutorials/Adding%20Analyzers%20at%20Runtime
@@ -368,7 +368,7 @@ string value"#;
 # and http://wiki.ros.org/diagnostics/Tutorials/Using%20the%20GenericAnalyzer
 # for examples of the structure of yaml files which are expected to have been
 # loaded into the namespace.
-string load_namespace"#;
+string load_namespace"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -387,14 +387,14 @@ string load_namespace"#;
     impl ::roslibrust::RosMessageType for AddDiagnosticsResponse {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/AddDiagnosticsResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"# True if diagnostic aggregator was updated with new diagnostics, False
+        const DEFINITION: &'static str = r####"# True if diagnostic aggregator was updated with new diagnostics, False
 # otherwise. A false return value means that either there is a bond in the
 # aggregator which already used the requested namespace, or the initialization
 # of analyzers failed.
 bool success
 
 # Message with additional information about the success or failure
-string message"#;
+string message"####;
     }
     #[allow(dead_code)]
     pub struct AddDiagnostics {}
@@ -418,7 +418,7 @@ string message"#;
     impl ::roslibrust::RosMessageType for SelfTestRequest {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/SelfTestRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -438,7 +438,7 @@ string message"#;
     impl ::roslibrust::RosMessageType for SelfTestResponse {
         const ROS_TYPE_NAME: &'static str = "diagnostic_msgs/SelfTestResponse";
         const MD5SUM: &'static str = "ac21b1bab7ab17546986536c22eb34e9";
-        const DEFINITION: &'static str = r#"string id
+        const DEFINITION: &'static str = r####"string id
 byte passed
 DiagnosticStatus[] status
 ================================================================================
@@ -472,7 +472,7 @@ MSG: diagnostic_msgs/KeyValue
 # What to label this value when viewing.
 string key
 # A value to track over time.
-string value"#;
+string value"####;
     }
     #[allow(dead_code)]
     pub struct SelfTest {}
@@ -513,7 +513,7 @@ pub mod geometry_msgs {
     impl ::roslibrust::RosMessageType for Accel {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Accel";
         const MD5SUM: &'static str = "9f195f881246fdfa2798d1d3eebca84a";
-        const DEFINITION: &'static str = r#"# This expresses acceleration in free space broken into its linear and angular parts.
+        const DEFINITION: &'static str = r####"# This expresses acceleration in free space broken into its linear and angular parts.
 Vector3  linear
 Vector3  angular
 ================================================================================
@@ -526,7 +526,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -545,7 +545,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for AccelStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelStamped";
         const MD5SUM: &'static str = "19a31cf6d39a90e769a5539f9a293621";
-        const DEFINITION: &'static str = r#"# An accel with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# An accel with reference coordinate frame and timestamp
 std_msgs/Header header
 Accel accel
 ================================================================================
@@ -585,7 +585,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -606,7 +606,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for AccelWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovariance";
         const MD5SUM: &'static str = "ad5a718d699c6be72a02b8d6a139f334";
-        const DEFINITION: &'static str = r#"# This expresses acceleration in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This expresses acceleration in free space with uncertainty.
 
 Accel accel
 
@@ -641,7 +641,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -660,7 +660,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for AccelWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/AccelWithCovarianceStamped";
         const MD5SUM: &'static str = "36b6f1177d3c3f476d4c306279c6f18a";
-        const DEFINITION: &'static str = r#"# This represents an estimated accel with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an estimated accel with reference coordinate frame and timestamp.
 std_msgs/Header header
 AccelWithCovariance accel
 ================================================================================
@@ -738,7 +738,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -763,7 +763,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Inertia {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Inertia";
         const MD5SUM: &'static str = "1d26e4bb6c83ff141c5cf0d883c2b0fe";
-        const DEFINITION: &'static str = r#"# Mass [kg]
+        const DEFINITION: &'static str = r####"# Mass [kg]
 float64 m
 
 # Center of mass [m]
@@ -789,7 +789,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -808,7 +808,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for InertiaStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/InertiaStamped";
         const MD5SUM: &'static str = "d4fb75ac056292d6c4bbec5e51d25080";
-        const DEFINITION: &'static str = r#"# An Inertia with a time stamp and reference frame.
+        const DEFINITION: &'static str = r####"# An Inertia with a time stamp and reference frame.
 
 std_msgs/Header header
 Inertia inertia
@@ -862,7 +862,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -882,10 +882,10 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Point {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Point";
         const MD5SUM: &'static str = "4a842b65f413084dc2b10fb484ea7f17";
-        const DEFINITION: &'static str = r#"# This contains the position of a point in free space
+        const DEFINITION: &'static str = r####"# This contains the position of a point in free space
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -905,7 +905,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for Point32 {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Point32";
         const MD5SUM: &'static str = "cc153912f1453b708d221682bc23d9ac";
-        const DEFINITION: &'static str = r#"# This contains the position of a point in free space(with 32 bits of precision).
+        const DEFINITION: &'static str = r####"# This contains the position of a point in free space(with 32 bits of precision).
 # It is recommended to use Point wherever possible instead of Point32.
 #
 # This recommendation is to promote interoperability.
@@ -915,7 +915,7 @@ float64 z"#;
 
 float32 x
 float32 y
-float32 z"#;
+float32 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -934,7 +934,7 @@ float32 z"#;
     impl ::roslibrust::RosMessageType for PointStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PointStamped";
         const MD5SUM: &'static str = "938cb86faf4572821e49e2490701e6df";
-        const DEFINITION: &'static str = r#"# This represents a Point with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Point with reference coordinate frame and timestamp
 
 std_msgs/Header header
 Point point
@@ -954,7 +954,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -972,7 +972,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Polygon {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Polygon";
         const MD5SUM: &'static str = "cd60a26494a087f577976f0329fa120e";
-        const DEFINITION: &'static str = r#"# A specification of a polygon where the first and last points are assumed to be connected
+        const DEFINITION: &'static str = r####"# A specification of a polygon where the first and last points are assumed to be connected
 
 Point32[] points
 ================================================================================
@@ -987,7 +987,7 @@ MSG: geometry_msgs/Point32
 
 float32 x
 float32 y
-float32 z"#;
+float32 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1006,7 +1006,7 @@ float32 z"#;
     impl ::roslibrust::RosMessageType for PolygonStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PolygonStamped";
         const MD5SUM: &'static str = "56a3a2a80165092f696df3db62e18fbf";
-        const DEFINITION: &'static str = r#"# This represents a Polygon with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Polygon with reference coordinate frame and timestamp
 
 std_msgs/Header header
 Polygon polygon
@@ -1051,7 +1051,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1070,7 +1070,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Pose {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Pose";
         const MD5SUM: &'static str = "e45d45a5a1ce597b249e23fb30fc871f";
-        const DEFINITION: &'static str = r#"# A representation of pose in free space, composed of position and orientation.
+        const DEFINITION: &'static str = r####"# A representation of pose in free space, composed of position and orientation.
 
 Point position
 Quaternion orientation
@@ -1087,7 +1087,7 @@ MSG: geometry_msgs/Quaternion
 float64 x 0
 float64 y 0
 float64 z 0
-float64 w 1"#;
+float64 w 1"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1107,7 +1107,7 @@ float64 w 1"#;
     impl ::roslibrust::RosMessageType for Pose2D {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Pose2D";
         const MD5SUM: &'static str = "938fa65709584ad8e77d238529be13b8";
-        const DEFINITION: &'static str = r#"# Deprecated as of Foxy and will potentially be removed in any following release.
+        const DEFINITION: &'static str = r####"# Deprecated as of Foxy and will potentially be removed in any following release.
 # Please use the full 3D pose.
 
 # In general our recommendation is to use a full 3D representation of everything and for 2D specific applications make the appropriate projections into the plane for their calculations but optimally will preserve the 3D information during processing.
@@ -1116,7 +1116,7 @@ float64 w 1"#;
 
 float64 x
 float64 y
-float64 theta"#;
+float64 theta"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1135,7 +1135,7 @@ float64 theta"#;
     impl ::roslibrust::RosMessageType for PoseArray {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseArray";
         const MD5SUM: &'static str = "ea7300c78ec47498d5f226be74a155e8";
-        const DEFINITION: &'static str = r#"# An array of poses with a header for global reference.
+        const DEFINITION: &'static str = r####"# An array of poses with a header for global reference.
 
 std_msgs/Header header
 
@@ -1184,7 +1184,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1203,7 +1203,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PoseStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseStamped";
         const MD5SUM: &'static str = "c088ec4a70a5930b0ca46520d5745e2d";
-        const DEFINITION: &'static str = r#"# A Pose with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A Pose with reference coordinate frame and timestamp
 
 std_msgs/Header header
 Pose pose
@@ -1251,7 +1251,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1272,7 +1272,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PoseWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovariance";
         const MD5SUM: &'static str = "c23e848cf1b7533a8d7c259073a97e6f";
-        const DEFINITION: &'static str = r#"# This represents a pose in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This represents a pose in free space with uncertainty.
 
 Pose pose
 
@@ -1314,7 +1314,7 @@ MSG: geometry_msgs/Quaternion
 float64 x 0
 float64 y 0
 float64 z 0
-float64 w 1"#;
+float64 w 1"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1333,7 +1333,7 @@ float64 w 1"#;
     impl ::roslibrust::RosMessageType for PoseWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/PoseWithCovarianceStamped";
         const MD5SUM: &'static str = "2178452bf195c1abe1e99b07b4e6c8f0";
-        const DEFINITION: &'static str = r#"# This expresses an estimated pose with a reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This expresses an estimated pose with a reference coordinate frame and timestamp
 
 std_msgs/Header header
 PoseWithCovariance pose
@@ -1426,7 +1426,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1451,12 +1451,12 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Quaternion {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Quaternion";
         const MD5SUM: &'static str = "a779879fadf0160734f906b8c19c7004";
-        const DEFINITION: &'static str = r#"# This represents an orientation in free space in quaternion form.
+        const DEFINITION: &'static str = r####"# This represents an orientation in free space in quaternion form.
 
 float64 x 0
 float64 y 0
 float64 z 0
-float64 w 1"#;
+float64 w 1"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1475,7 +1475,7 @@ float64 w 1"#;
     impl ::roslibrust::RosMessageType for QuaternionStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/QuaternionStamped";
         const MD5SUM: &'static str = "8f93ed7c8430d06bd82fefcc6f7a349e";
-        const DEFINITION: &'static str = r#"# This represents an orientation with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an orientation with reference coordinate frame and timestamp.
 
 std_msgs/Header header
 Quaternion quaternion
@@ -1497,7 +1497,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1516,7 +1516,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Transform {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Transform";
         const MD5SUM: &'static str = "ac9eff44abf714214112b05d54a3cf9b";
-        const DEFINITION: &'static str = r#"# This represents the transform between two coordinate frames in free space.
+        const DEFINITION: &'static str = r####"# This represents the transform between two coordinate frames in free space.
 
 Vector3 translation
 Quaternion rotation
@@ -1538,7 +1538,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1558,7 +1558,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TransformStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TransformStamped";
         const MD5SUM: &'static str = "09bf247c06cf7c69e8c55300b05a7a04";
-        const DEFINITION: &'static str = r#"# This expresses a transform from coordinate frame header.frame_id
+        const DEFINITION: &'static str = r####"# This expresses a transform from coordinate frame header.frame_id
 # to the coordinate frame child_frame_id at the time of header.stamp
 #
 # This message is mostly used by the
@@ -1631,7 +1631,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1650,7 +1650,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Twist {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Twist";
         const MD5SUM: &'static str = "9f195f881246fdfa2798d1d3eebca84a";
-        const DEFINITION: &'static str = r#"# This expresses velocity in free space broken into its linear and angular parts.
+        const DEFINITION: &'static str = r####"# This expresses velocity in free space broken into its linear and angular parts.
 
 Vector3  linear
 Vector3  angular
@@ -1664,7 +1664,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1683,7 +1683,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TwistStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistStamped";
         const MD5SUM: &'static str = "09f84400c1ca2e7e26a9da1232813bd0";
-        const DEFINITION: &'static str = r#"# A twist with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A twist with reference coordinate frame and timestamp
 
 std_msgs/Header header
 Twist twist
@@ -1725,7 +1725,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1746,7 +1746,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for TwistWithCovariance {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovariance";
         const MD5SUM: &'static str = "1fe8a28e6890a4cc3ae4c3ca5c7d82e6";
-        const DEFINITION: &'static str = r#"# This expresses velocity in free space with uncertainty.
+        const DEFINITION: &'static str = r####"# This expresses velocity in free space with uncertainty.
 
 Twist twist
 
@@ -1782,7 +1782,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1801,7 +1801,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for TwistWithCovarianceStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/TwistWithCovarianceStamped";
         const MD5SUM: &'static str = "7019807c85ce8602fb83180366470670";
-        const DEFINITION: &'static str = r#"# This represents an estimated twist with reference coordinate frame and timestamp.
+        const DEFINITION: &'static str = r####"# This represents an estimated twist with reference coordinate frame and timestamp.
 
 std_msgs/Header header
 TwistWithCovariance twist
@@ -1882,7 +1882,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1902,7 +1902,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Vector3 {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Vector3";
         const MD5SUM: &'static str = "4a842b65f413084dc2b10fb484ea7f17";
-        const DEFINITION: &'static str = r#"# This represents a vector in free space.
+        const DEFINITION: &'static str = r####"# This represents a vector in free space.
 
 # This is semantically different than a point.
 # A vector is always anchored at the origin.
@@ -1910,7 +1910,7 @@ string frame_id"#;
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1929,7 +1929,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for Vector3Stamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Vector3Stamped";
         const MD5SUM: &'static str = "5cd361f2989a2e76d5aaf432c3bf0fb9";
-        const DEFINITION: &'static str = r#"# This represents a Vector3 with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# This represents a Vector3 with reference coordinate frame and timestamp
 
 # Note that this follows vector semantics with it always anchored at the origin,
 # so the rotational elements of a transform are the only parts applied when transforming.
@@ -1957,7 +1957,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -1976,7 +1976,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Wrench {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/Wrench";
         const MD5SUM: &'static str = "4f539cf138b23283b520fd271b567936";
-        const DEFINITION: &'static str = r#"# This represents force in free space, separated into its linear and angular parts.
+        const DEFINITION: &'static str = r####"# This represents force in free space, separated into its linear and angular parts.
 
 Vector3  force
 Vector3  torque
@@ -1990,7 +1990,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2009,7 +2009,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for WrenchStamped {
         const ROS_TYPE_NAME: &'static str = "geometry_msgs/WrenchStamped";
         const MD5SUM: &'static str = "5bc71556ab354cd6274d262a7de094a5";
-        const DEFINITION: &'static str = r#"# A wrench with reference coordinate frame and timestamp
+        const DEFINITION: &'static str = r####"# A wrench with reference coordinate frame and timestamp
 
 std_msgs/Header header
 Wrench wrench
@@ -2051,7 +2051,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -2086,7 +2086,7 @@ pub mod nav_msgs {
     impl ::roslibrust::RosMessageType for GridCells {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GridCells";
         const MD5SUM: &'static str = "bb9f07bfd2183241b5719f45a81f8cc5";
-        const DEFINITION: &'static str = r#"# An array of cells in a 2D grid
+        const DEFINITION: &'static str = r####"# An array of cells in a 2D grid
 
 std_msgs/Header header
 
@@ -2114,7 +2114,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2136,7 +2136,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MapMetaData {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/MapMetaData";
         const MD5SUM: &'static str = "d10232bae3de4ae536d98f679fce2cf2";
-        const DEFINITION: &'static str = r#"# This hold basic information about the characteristics of the OccupancyGrid
+        const DEFINITION: &'static str = r####"# This hold basic information about the characteristics of the OccupancyGrid
 
 # The time at which the map was loaded
 builtin_interfaces/Time map_load_time
@@ -2186,7 +2186,7 @@ MSG: geometry_msgs/Quaternion
 float64 x 0
 float64 y 0
 float64 z 0
-float64 w 1"#;
+float64 w 1"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2206,7 +2206,7 @@ float64 w 1"#;
     impl ::roslibrust::RosMessageType for OccupancyGrid {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/OccupancyGrid";
         const MD5SUM: &'static str = "2b0657f1993991bf3953916eb5ff5203";
-        const DEFINITION: &'static str = r#"# This represents a 2-D grid map
+        const DEFINITION: &'static str = r####"# This represents a 2-D grid map
 std_msgs/Header header
 
 # MetaData for the map
@@ -2316,7 +2316,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2337,7 +2337,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Odometry {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Odometry";
         const MD5SUM: &'static str = "81a0900daae2c6c0acc71c9f8df88947";
-        const DEFINITION: &'static str = r#"# This represents an estimate of a position and velocity in free space.
+        const DEFINITION: &'static str = r####"# This represents an estimate of a position and velocity in free space.
 # The pose in this message should be specified in the coordinate frame given by header.frame_id
 # The twist in this message should be specified in the coordinate frame given by the child_frame_id
 
@@ -2508,7 +2508,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2527,7 +2527,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Path {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/Path";
         const MD5SUM: &'static str = "9f78b006a4c2cc2a146c12ed59d1bb7f";
-        const DEFINITION: &'static str = r#"# An array of poses that represents a Path for a robot to follow.
+        const DEFINITION: &'static str = r####"# An array of poses that represents a Path for a robot to follow.
 
 # Indicates the frame_id of the path.
 std_msgs/Header header
@@ -2629,7 +2629,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2645,7 +2645,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#"# Get the map as a nav_msgs/OccupancyGrid"#;
+        const DEFINITION: &'static str = r####"# Get the map as a nav_msgs/OccupancyGrid"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -2663,7 +2663,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetMapResponse";
         const MD5SUM: &'static str = "d6e8b0301af2dfe2244959ba20a4080a";
-        const DEFINITION: &'static str = r#"# The current map hosted by this map service.
+        const DEFINITION: &'static str = r####"# The current map hosted by this map service.
 OccupancyGrid map
 ================================================================================
 MSG: geometry_msgs/Point
@@ -2875,7 +2875,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(dead_code)]
     pub struct GetMap {}
@@ -2903,7 +2903,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetPlanRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetPlanRequest";
         const MD5SUM: &'static str = "e4855e4d3c7377c76ec90e403202286a";
-        const DEFINITION: &'static str = r#"# Get a plan from the current position to the goal Pose
+        const DEFINITION: &'static str = r####"# Get a plan from the current position to the goal Pose
 
 # The start pose for the plan
 geometry_msgs/PoseStamped start
@@ -3009,7 +3009,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3027,7 +3027,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for GetPlanResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/GetPlanResponse";
         const MD5SUM: &'static str = "37c13f9b42d0ee04e1dae0d4f7d14878";
-        const DEFINITION: &'static str = r#"# Array of poses from start to goal if one was successfully found.
+        const DEFINITION: &'static str = r####"# Array of poses from start to goal if one was successfully found.
 Path plan
 ================================================================================
 MSG: geometry_msgs/Point
@@ -3229,7 +3229,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(dead_code)]
     pub struct GetPlan {}
@@ -3255,10 +3255,10 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for LoadMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/LoadMapRequest";
         const MD5SUM: &'static str = "3813ba1ae85fbcd4dc88c90f1426b90b";
-        const DEFINITION: &'static str = r#"# URL of map resource
+        const DEFINITION: &'static str = r####"# URL of map resource
 # Can be an absolute path to a file: file:///path/to/maps/floor1.yaml
 # Or, relative to a ROS package: package://my_ros_package/maps/floor2.yaml
-string map_url"#;
+string map_url"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3277,7 +3277,7 @@ string map_url"#;
     impl ::roslibrust::RosMessageType for LoadMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/LoadMapResponse";
         const MD5SUM: &'static str = "cdb849e3dfaed8b5fe66776d7a64b83e";
-        const DEFINITION: &'static str = r#"# Result code defintions
+        const DEFINITION: &'static str = r####"# Result code defintions
 uint8 RESULT_SUCCESS=0
 uint8 RESULT_MAP_DOES_NOT_EXIST=1
 uint8 RESULT_INVALID_MAP_DATA=2
@@ -3497,7 +3497,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl LoadMapResponse {
@@ -3532,7 +3532,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetMapRequest {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapRequest";
         const MD5SUM: &'static str = "98782a373ad73e1165352caf85923850";
-        const DEFINITION: &'static str = r#"# Set a new map together with an initial pose
+        const DEFINITION: &'static str = r####"# Set a new map together with an initial pose
 
 # Requested 2D map to be set.
 nav_msgs/OccupancyGrid map
@@ -3890,7 +3890,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -3908,8 +3908,8 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetMapResponse {
         const ROS_TYPE_NAME: &'static str = "nav_msgs/SetMapResponse";
         const MD5SUM: &'static str = "358e233cde0c8a8bcfea4ce193f8fc15";
-        const DEFINITION: &'static str = r#"# True if the map was successfully set, false otherwise.
-bool success"#;
+        const DEFINITION: &'static str = r####"# True if the map was successfully set, false otherwise.
+bool success"####;
     }
     #[allow(dead_code)]
     pub struct SetMap {}
@@ -3964,7 +3964,7 @@ pub mod sensor_msgs {
     impl ::roslibrust::RosMessageType for BatteryState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/BatteryState";
         const MD5SUM: &'static str = "0e25cedcd370a46961764fe3a9d2ddcb";
-        const DEFINITION: &'static str = r#"# Constants are chosen to match the enums in the linux kernel
+        const DEFINITION: &'static str = r####"# Constants are chosen to match the enums in the linux kernel
 # defined in include/linux/power_supply.h as of version 3.7
 # The one difference is for style reasons the constants are
 # all uppercase not mixed case.
@@ -4025,7 +4025,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl BatteryState {
@@ -4077,7 +4077,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for CameraInfo {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CameraInfo";
         const MD5SUM: &'static str = "47b55ddbbf2ec398f94cddf328bbc2ac";
-        const DEFINITION: &'static str = r#"# This message defines meta information for a camera. It should be in a
+        const DEFINITION: &'static str = r####"# This message defines meta information for a camera. It should be in a
 # camera namespace on topic "camera_info" and accompanied by up to five
 # image topics named:
 #
@@ -4239,7 +4239,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4258,7 +4258,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for ChannelFloat32 {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/ChannelFloat32";
         const MD5SUM: &'static str = "3d40139cdd33dfedcb71ffeeeb42ae7f";
-        const DEFINITION: &'static str = r#"# This message is used by the PointCloud message to hold optional data
+        const DEFINITION: &'static str = r####"# This message is used by the PointCloud message to hold optional data
 # associated with each point in the cloud. The length of the values
 # array should be the same as the length of the points array in the
 # PointCloud, and each value should be associated with the corresponding
@@ -4281,7 +4281,7 @@ string name
 
 # The values array should be 1-1 with the elements of the associated
 # PointCloud.
-float32[] values"#;
+float32[] values"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4302,7 +4302,7 @@ float32[] values"#;
     impl ::roslibrust::RosMessageType for CompressedImage {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/CompressedImage";
         const MD5SUM: &'static str = "1df88053b24348f5f499666c7cb1d980";
-        const DEFINITION: &'static str = r#"# This message contains a compressed image.
+        const DEFINITION: &'static str = r####"# This message contains a compressed image.
 
 std_msgs/Header header # Header timestamp should be acquisition time of image
                              # Header frame_id should be optical frame of camera
@@ -4326,7 +4326,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4346,7 +4346,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for FluidPressure {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/FluidPressure";
         const MD5SUM: &'static str = "4967e6ff4dcf72e6b8fca0600661e0b6";
-        const DEFINITION: &'static str = r#"# Single pressure reading.  This message is appropriate for measuring the
+        const DEFINITION: &'static str = r####"# Single pressure reading.  This message is appropriate for measuring the
 # pressure inside of a fluid (air, water, etc).  This also includes
 # atmospheric or barometric pressure.
 #
@@ -4368,7 +4368,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4388,7 +4388,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Illuminance {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Illuminance";
         const MD5SUM: &'static str = "94ccac1a1be684df74466dfc561512aa";
-        const DEFINITION: &'static str = r#"# Single photometric illuminance measurement.  Light should be assumed to be
+        const DEFINITION: &'static str = r####"# Single photometric illuminance measurement.  Light should be assumed to be
 # measured along the sensor's x-axis (the area of detection is the y-z plane).
 # The illuminance should have a 0 or positive value and be received with
 # the sensor's +X axis pointing toward the light source.
@@ -4418,7 +4418,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4443,7 +4443,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Image {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Image";
         const MD5SUM: &'static str = "9c8b3d25a28b72f070da359dbecf985b";
-        const DEFINITION: &'static str = r#"# This message contains an uncompressed image
+        const DEFINITION: &'static str = r####"# This message contains an uncompressed image
 # (0, 0) is at top-left corner of image
 
 std_msgs/Header header # Header timestamp should be acquisition time of image
@@ -4479,7 +4479,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4503,7 +4503,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Imu {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Imu";
         const MD5SUM: &'static str = "058a92f712764b4ade1563e82041c569";
-        const DEFINITION: &'static str = r#"# This is a message to hold data from an IMU (Inertial Measurement Unit)
+        const DEFINITION: &'static str = r####"# This is a message to hold data from an IMU (Inertial Measurement Unit)
 #
 # Accelerations should be in m/s^2 (not in g's), and rotational velocity should be in rad/sec
 #
@@ -4556,7 +4556,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4578,7 +4578,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for JointState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JointState";
         const MD5SUM: &'static str = "3f61f1439a9898cdd864497d378ce55c";
-        const DEFINITION: &'static str = r#"# This is a message that holds data to describe the state of a set of torque controlled joints.
+        const DEFINITION: &'static str = r####"# This is a message that holds data to describe the state of a set of torque controlled joints.
 #
 # The state of each joint (revolute or prismatic) is defined by:
 #  * the position of the joint (rad or m),
@@ -4613,7 +4613,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4633,7 +4633,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Joy {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Joy";
         const MD5SUM: &'static str = "967f985c9ca9013a4669430613e3e016";
-        const DEFINITION: &'static str = r#"# Reports the state of a joystick's axes and buttons.
+        const DEFINITION: &'static str = r####"# Reports the state of a joystick's axes and buttons.
 
 # The timestamp is the time at which data is received from the joystick.
 std_msgs/Header header
@@ -4653,7 +4653,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4673,7 +4673,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for JoyFeedback {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JoyFeedback";
         const MD5SUM: &'static str = "f4dcd73460360d98f36e55ee7f2e46f1";
-        const DEFINITION: &'static str = r#"# Declare of the type of feedback
+        const DEFINITION: &'static str = r####"# Declare of the type of feedback
 uint8 TYPE_LED    = 0
 uint8 TYPE_RUMBLE = 1
 uint8 TYPE_BUZZER = 2
@@ -4686,7 +4686,7 @@ uint8 id
 
 # Intensity of the feedback, from 0.0 to 1.0, inclusive.  If device is
 # actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.
-float32 intensity"#;
+float32 intensity"####;
     }
     #[allow(unused)]
     impl JoyFeedback {
@@ -4710,7 +4710,7 @@ float32 intensity"#;
     impl ::roslibrust::RosMessageType for JoyFeedbackArray {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/JoyFeedbackArray";
         const MD5SUM: &'static str = "cde5730a895b1fc4dee6f91b754b213d";
-        const DEFINITION: &'static str = r#"# This message publishes values for multiple feedback at once.
+        const DEFINITION: &'static str = r####"# This message publishes values for multiple feedback at once.
 JoyFeedback[] array
 ================================================================================
 MSG: sensor_msgs/JoyFeedback
@@ -4727,7 +4727,7 @@ uint8 id
 
 # Intensity of the feedback, from 0.0 to 1.0, inclusive.  If device is
 # actually binary, driver should treat 0<=x<0.5 as off, 0.5<=x<=1 as on.
-float32 intensity"#;
+float32 intensity"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4745,11 +4745,11 @@ float32 intensity"#;
     impl ::roslibrust::RosMessageType for LaserEcho {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/LaserEcho";
         const MD5SUM: &'static str = "8bc5ae449b200fba4d552b4225586696";
-        const DEFINITION: &'static str = r#"# This message is a submessage of MultiEchoLaserScan and is not intended
+        const DEFINITION: &'static str = r####"# This message is a submessage of MultiEchoLaserScan and is not intended
 # to be used separately.
 
 float32[] echoes  # Multiple values of ranges or intensities.
-                  # Each array represents data from the same angle increment."#;
+                  # Each array represents data from the same angle increment."####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4776,7 +4776,7 @@ float32[] echoes  # Multiple values of ranges or intensities.
     impl ::roslibrust::RosMessageType for LaserScan {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/LaserScan";
         const MD5SUM: &'static str = "f86984b4383bf67523c75820e114e988";
-        const DEFINITION: &'static str = r#"# Single scan from a planar laser range-finder
+        const DEFINITION: &'static str = r####"# Single scan from a planar laser range-finder
 #
 # If you have another ranging device with different behavior (e.g. a sonar
 # array), please find or create a different message, since applications
@@ -4816,7 +4816,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4836,7 +4836,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MagneticField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MagneticField";
         const MD5SUM: &'static str = "c8761d20eb9dc59addd882f1d4de2266";
-        const DEFINITION: &'static str = r#"# Measurement of the Magnetic Field vector at a specific location.
+        const DEFINITION: &'static str = r####"# Measurement of the Magnetic Field vector at a specific location.
 #
 # If the covariance of the measurement is known, it should be filled in.
 # If all you know is the variance of each measurement, e.g. from the datasheet,
@@ -4878,7 +4878,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -4900,7 +4900,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointState {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MultiDOFJointState";
         const MD5SUM: &'static str = "9eb02d78422731545fd7e9b60069f261";
-        const DEFINITION: &'static str = r#"# Representation of state for joints with multiple degrees of freedom,
+        const DEFINITION: &'static str = r####"# Representation of state for joints with multiple degrees of freedom,
 # following the structure of JointState which can only represent a single degree of freedom.
 #
 # It is assumed that a joint in a system corresponds to a transform that gets applied
@@ -5014,7 +5014,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5041,7 +5041,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for MultiEchoLaserScan {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/MultiEchoLaserScan";
         const MD5SUM: &'static str = "fda674281c16cdee9a79d075ab27d12f";
-        const DEFINITION: &'static str = r#"# Single scan from a multi-echo planar laser range-finder
+        const DEFINITION: &'static str = r####"# Single scan from a multi-echo planar laser range-finder
 #
 # If you have another ranging device with different behavior (e.g. a sonar
 # array), please find or create a different message, since applications
@@ -5090,7 +5090,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5114,7 +5114,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for NavSatFix {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatFix";
         const MD5SUM: &'static str = "faa1756146a6a934d7e4ef0e3855c531";
-        const DEFINITION: &'static str = r#"# Navigation Satellite fix for any Global Navigation Satellite System
+        const DEFINITION: &'static str = r####"# Navigation Satellite fix for any Global Navigation Satellite System
 #
 # Specified using the WGS 84 reference ellipsoid
 
@@ -5193,7 +5193,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl NavSatFix {
@@ -5219,7 +5219,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for NavSatStatus {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/NavSatStatus";
         const MD5SUM: &'static str = "331cdbddfa4bc96ffc3b9ad98900a54c";
-        const DEFINITION: &'static str = r#"# Navigation Satellite fix status for any Global Navigation Satellite System.
+        const DEFINITION: &'static str = r####"# Navigation Satellite fix status for any Global Navigation Satellite System.
 #
 # Whether to output an augmented fix is determined by both the fix
 # type and the last time differential corrections were received.  A
@@ -5240,7 +5240,7 @@ uint16 SERVICE_GLONASS = 2
 uint16 SERVICE_COMPASS = 4      # includes BeiDou.
 uint16 SERVICE_GALILEO = 8
 
-uint16 service"#;
+uint16 service"####;
     }
     #[allow(unused)]
     impl NavSatStatus {
@@ -5271,7 +5271,7 @@ uint16 service"#;
     impl ::roslibrust::RosMessageType for PointCloud {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointCloud";
         const MD5SUM: &'static str = "95c9c548e015c235b38b961c79973db7";
-        const DEFINITION: &'static str = r#"## THIS MESSAGE IS DEPRECATED AS OF FOXY
+        const DEFINITION: &'static str = r####"## THIS MESSAGE IS DEPRECATED AS OF FOXY
 ## Please use sensor_msgs/PointCloud2
 
 # This message holds a collection of 3d points, plus optional additional
@@ -5337,7 +5337,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5364,7 +5364,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PointCloud2 {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointCloud2";
         const MD5SUM: &'static str = "c61ffb665fe19735825e4dd31b53913d";
-        const DEFINITION: &'static str = r#"# This message holds a collection of N-dimensional points, which may
+        const DEFINITION: &'static str = r####"# This message holds a collection of N-dimensional points, which may
 # contain additional information such as normals, intensity, etc. The
 # point data is stored as a binary blob, its layout described by the
 # contents of the "fields" array.
@@ -5418,7 +5418,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5439,7 +5439,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for PointField {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/PointField";
         const MD5SUM: &'static str = "268eacb2962780ceac86cbd17e328150";
-        const DEFINITION: &'static str = r#"# This message holds the description of one point entry in the
+        const DEFINITION: &'static str = r####"# This message holds the description of one point entry in the
 # PointCloud2 message format.
 uint8 INT8    = 1
 uint8 UINT8   = 2
@@ -5454,7 +5454,7 @@ uint8 FLOAT64 = 8
 string name      # Name of field
 uint32 offset    # Offset from start of point struct
 uint8  datatype  # Datatype enumeration, see above
-uint32 count     # How many elements in the field"#;
+uint32 count     # How many elements in the field"####;
     }
     #[allow(unused)]
     impl PointField {
@@ -5488,7 +5488,7 @@ uint32 count     # How many elements in the field"#;
     impl ::roslibrust::RosMessageType for Range {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Range";
         const MD5SUM: &'static str = "1ec40687acdf15b9559a6ff690722eae";
-        const DEFINITION: &'static str = r#"# Single range reading from an active ranger that emits energy and reports
+        const DEFINITION: &'static str = r####"# Single range reading from an active ranger that emits energy and reports
 # one range reading that is valid along an arc at the distance measured.
 # This message is  not appropriate for laser scanners. See the LaserScan
 # message if you are working with a laser scanner.
@@ -5537,7 +5537,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl Range {
@@ -5564,7 +5564,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for RegionOfInterest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/RegionOfInterest";
         const MD5SUM: &'static str = "bdb633039d588fcccb441a4d43ccfe09";
-        const DEFINITION: &'static str = r#"# This message is used to specify a region of interest within an image.
+        const DEFINITION: &'static str = r####"# This message is used to specify a region of interest within an image.
 #
 # When used to specify the ROI setting of the camera when the image was
 # taken, the height and width fields should either match the height and
@@ -5582,7 +5582,7 @@ uint32 width     # Width of ROI
 # ROI in this message. Typically this should be False if the full image
 # is captured (ROI not used), and True if a subwindow is captured (ROI
 # used).
-bool do_rectify"#;
+bool do_rectify"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5602,7 +5602,7 @@ bool do_rectify"#;
     impl ::roslibrust::RosMessageType for RelativeHumidity {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/RelativeHumidity";
         const MD5SUM: &'static str = "71cfefa31dcc94f47083b1e89e6fa5c9";
-        const DEFINITION: &'static str = r#"# Single reading from a relative humidity sensor.
+        const DEFINITION: &'static str = r####"# Single reading from a relative humidity sensor.
 # Defines the ratio of partial pressure of water vapor to the saturated vapor
 # pressure at a temperature.
 
@@ -5625,7 +5625,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5645,7 +5645,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Temperature {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/Temperature";
         const MD5SUM: &'static str = "c6df0674fcfebff84a15927a80ebb14b";
-        const DEFINITION: &'static str = r#"# Single temperature reading.
+        const DEFINITION: &'static str = r####"# Single temperature reading.
 
 std_msgs/Header header # timestamp is the time the temperature was measured
                              # frame_id is the location of the temperature reading
@@ -5663,7 +5663,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5683,7 +5683,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for TimeReference {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/TimeReference";
         const MD5SUM: &'static str = "7cb7ae5aa838323e9028637e304e0ad7";
-        const DEFINITION: &'static str = r#"# Measurement from an external time source not actively synchronized with the system clock.
+        const DEFINITION: &'static str = r####"# Measurement from an external time source not actively synchronized with the system clock.
 
 std_msgs/Header header      # stamp is system time for which measurement was valid
                                   # frame_id is not used
@@ -5700,7 +5700,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5718,7 +5718,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetCameraInfoRequest {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoRequest";
         const MD5SUM: &'static str = "251c96e357751cc7c699c496178141d5";
-        const DEFINITION: &'static str = r#"# This service requests that a camera stores the given CameraInfo as that
+        const DEFINITION: &'static str = r####"# This service requests that a camera stores the given CameraInfo as that
 # camera's calibration information.
 #
 # The width and height in the camera_info field should match what the
@@ -5923,7 +5923,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -5942,8 +5942,8 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for SetCameraInfoResponse {
         const ROS_TYPE_NAME: &'static str = "sensor_msgs/SetCameraInfoResponse";
         const MD5SUM: &'static str = "2ec6f3eff0161f4257b808b12bc830c2";
-        const DEFINITION: &'static str = r#"bool success                             # True if the call succeeded
-string status_message                    # Used to give details about success"#;
+        const DEFINITION: &'static str = r####"bool success                             # True if the call succeeded
+string status_message                    # Used to give details about success"####;
     }
     #[allow(dead_code)]
     pub struct SetCameraInfo {}
@@ -5984,7 +5984,7 @@ pub mod shape_msgs {
     impl ::roslibrust::RosMessageType for Mesh {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Mesh";
         const MD5SUM: &'static str = "1ffdae9486cd3316a121c578b47a85cc";
-        const DEFINITION: &'static str = r#"# Definition of a mesh.
+        const DEFINITION: &'static str = r####"# Definition of a mesh.
 
 # List of triangles; the index values refer to positions in vertices[].
 MeshTriangle[] triangles
@@ -6001,7 +6001,7 @@ float64 z
 MSG: shape_msgs/MeshTriangle
 # Definition of a triangle's vertices.
 
-uint32[3] vertex_indices"#;
+uint32[3] vertex_indices"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6019,9 +6019,9 @@ uint32[3] vertex_indices"#;
     impl ::roslibrust::RosMessageType for MeshTriangle {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/MeshTriangle";
         const MD5SUM: &'static str = "23688b2e6d2de3d32fe8af104a903253";
-        const DEFINITION: &'static str = r#"# Definition of a triangle's vertices.
+        const DEFINITION: &'static str = r####"# Definition of a triangle's vertices.
 
-uint32[3] vertex_indices"#;
+uint32[3] vertex_indices"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6039,13 +6039,13 @@ uint32[3] vertex_indices"#;
     impl ::roslibrust::RosMessageType for Plane {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/Plane";
         const MD5SUM: &'static str = "2c1b92ed8f31492f8e73f6a4a44ca796";
-        const DEFINITION: &'static str = r#"# Representation of a plane, using the plane equation ax + by + cz + d = 0.
+        const DEFINITION: &'static str = r####"# Representation of a plane, using the plane equation ax + by + cz + d = 0.
 #
 # a := coef[0]
 # b := coef[1]
 # c := coef[2]
 # d := coef[3]
-float64[4] coef"#;
+float64[4] coef"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6065,7 +6065,7 @@ float64[4] coef"#;
     impl ::roslibrust::RosMessageType for SolidPrimitive {
         const ROS_TYPE_NAME: &'static str = "shape_msgs/SolidPrimitive";
         const MD5SUM: &'static str = "0cdf91a0a45ccd7bc1e0deb784cb2958";
-        const DEFINITION: &'static str = r#"# Defines box, sphere, cylinder, cone and prism.
+        const DEFINITION: &'static str = r####"# Defines box, sphere, cylinder, cone and prism.
 # All shapes are defined to have their bounding boxes centered around 0,0,0.
 
 uint8 BOX=1
@@ -6145,7 +6145,7 @@ MSG: geometry_msgs/Point32
 
 float32 x
 float32 y
-float32 z"#;
+float32 z"####;
     }
     #[allow(unused)]
     impl SolidPrimitive {
@@ -6194,12 +6194,12 @@ pub mod std_msgs {
     impl ::roslibrust::RosMessageType for Bool {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Bool";
         const MD5SUM: &'static str = "8b94c1b53db61fb6aed406028ad6332a";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-bool data"#;
+bool data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6217,12 +6217,12 @@ bool data"#;
     impl ::roslibrust::RosMessageType for Byte {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Byte";
         const MD5SUM: &'static str = "ad736a2e8818154c487bb80fe42ce43b";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-byte data"#;
+byte data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6241,7 +6241,7 @@ byte data"#;
     impl ::roslibrust::RosMessageType for ByteMultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/ByteMultiArray";
         const MD5SUM: &'static str = "70ea476cbcfd65ac2f68f3cda1e891fe";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6303,7 +6303,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6321,12 +6321,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Char {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Char";
         const MD5SUM: &'static str = "1bf77f25acecdedba0e224b162199717";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-char data"#;
+char data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6347,10 +6347,10 @@ char data"#;
     impl ::roslibrust::RosMessageType for ColorRGBA {
         const ROS_TYPE_NAME: &'static str = "std_msgs/ColorRGBA";
         const MD5SUM: &'static str = "a29a96539573343b1310c73607334b00";
-        const DEFINITION: &'static str = r#"float32 r
+        const DEFINITION: &'static str = r####"float32 r
 float32 g
 float32 b
-float32 a"#;
+float32 a"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6366,7 +6366,7 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Empty {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Empty";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6384,12 +6384,12 @@ float32 a"#;
     impl ::roslibrust::RosMessageType for Float32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float32";
         const MD5SUM: &'static str = "73fcbf46b49191e672908e50842a83d4";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-float32 data"#;
+float32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6408,7 +6408,7 @@ float32 data"#;
     impl ::roslibrust::RosMessageType for Float32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float32MultiArray";
         const MD5SUM: &'static str = "6a40e0ffa6a17a503ac3f8616991b1f6";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6470,7 +6470,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6488,12 +6488,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Float64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float64";
         const MD5SUM: &'static str = "fdb28210bfa9d7c91146260178d9a584";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-float64 data"#;
+float64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6512,7 +6512,7 @@ float64 data"#;
     impl ::roslibrust::RosMessageType for Float64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Float64MultiArray";
         const MD5SUM: &'static str = "4b7d974086d4060e7db4613a7e6c3ba4";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6574,7 +6574,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6593,7 +6593,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Header {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Header";
         const MD5SUM: &'static str = "5ed6b5dd1ef879ffb9c2ac51bab61a63";
-        const DEFINITION: &'static str = r#"# Standard metadata for higher-level stamped data types.
+        const DEFINITION: &'static str = r####"# Standard metadata for higher-level stamped data types.
 # This is generally used to communicate timestamped data
 # in a particular coordinate frame.
 
@@ -6601,7 +6601,7 @@ uint32 stride  # stride of given dimension"#;
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6619,12 +6619,12 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for Int16 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int16";
         const MD5SUM: &'static str = "8524586e34fbd7cb1c08c5f5f1ca0e57";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-int16 data"#;
+int16 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6643,7 +6643,7 @@ int16 data"#;
     impl ::roslibrust::RosMessageType for Int16MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int16MultiArray";
         const MD5SUM: &'static str = "d9338d7f523fcb692fae9d0a0e9f067c";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6705,7 +6705,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6723,12 +6723,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int32";
         const MD5SUM: &'static str = "da5909fbe378aeaf85e547e830cc1bb7";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-int32 data"#;
+int32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6747,7 +6747,7 @@ int32 data"#;
     impl ::roslibrust::RosMessageType for Int32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int32MultiArray";
         const MD5SUM: &'static str = "1d99f79f8b325b44fee908053e9c945b";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6809,7 +6809,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6827,12 +6827,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int64";
         const MD5SUM: &'static str = "34add168574510e6e17f5d23ecc077ef";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-int64 data"#;
+int64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6851,7 +6851,7 @@ int64 data"#;
     impl ::roslibrust::RosMessageType for Int64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int64MultiArray";
         const MD5SUM: &'static str = "54865aa6c65be0448113a2afc6a49270";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -6913,7 +6913,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6931,12 +6931,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for Int8 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int8";
         const MD5SUM: &'static str = "27ffa0c9c4b8fb8492252bcad9e5c57b";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-int8 data"#;
+int8 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -6955,7 +6955,7 @@ int8 data"#;
     impl ::roslibrust::RosMessageType for Int8MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/Int8MultiArray";
         const MD5SUM: &'static str = "d7c1af35a1b4781bbe79e03dd94b7c13";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7017,7 +7017,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7037,14 +7037,14 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for MultiArrayDimension {
         const ROS_TYPE_NAME: &'static str = "std_msgs/MultiArrayDimension";
         const MD5SUM: &'static str = "4cd0c83a8683deae40ecdac60e53bfa8";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7063,7 +7063,7 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for MultiArrayLayout {
         const ROS_TYPE_NAME: &'static str = "std_msgs/MultiArrayLayout";
         const MD5SUM: &'static str = "0fed2a11c13e11c5571b4e2a995a91a3";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7103,7 +7103,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7121,12 +7121,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for String {
         const ROS_TYPE_NAME: &'static str = "std_msgs/String";
         const MD5SUM: &'static str = "992ce8a1687cec8c8bd883ec73ca41d1";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-string data"#;
+string data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7144,12 +7144,12 @@ string data"#;
     impl ::roslibrust::RosMessageType for UInt16 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt16";
         const MD5SUM: &'static str = "1df79edf208b629fe6b81923a544552d";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-uint16 data"#;
+uint16 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7168,7 +7168,7 @@ uint16 data"#;
     impl ::roslibrust::RosMessageType for UInt16MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt16MultiArray";
         const MD5SUM: &'static str = "52f264f1c973c4b73790d384c6cb4484";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7230,7 +7230,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7248,12 +7248,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt32 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt32";
         const MD5SUM: &'static str = "304a39449588c7f8ce2df6e8001c5fce";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-uint32 data"#;
+uint32 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7272,7 +7272,7 @@ uint32 data"#;
     impl ::roslibrust::RosMessageType for UInt32MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt32MultiArray";
         const MD5SUM: &'static str = "4d6a180abc9be191b96a7eda6c8a233d";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7334,7 +7334,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7352,12 +7352,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt64 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt64";
         const MD5SUM: &'static str = "1b2a79973e8bf53d7b53acb71299cb57";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-uint64 data"#;
+uint64 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7376,7 +7376,7 @@ uint64 data"#;
     impl ::roslibrust::RosMessageType for UInt64MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt64MultiArray";
         const MD5SUM: &'static str = "6088f127afb1d6c72927aa1247e945af";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7438,7 +7438,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7456,12 +7456,12 @@ uint32 stride  # stride of given dimension"#;
     impl ::roslibrust::RosMessageType for UInt8 {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt8";
         const MD5SUM: &'static str = "7c8164229e7d2c17eb95e9231617fdee";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
 
-uint8 data"#;
+uint8 data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7481,7 +7481,7 @@ uint8 data"#;
     impl ::roslibrust::RosMessageType for UInt8MultiArray {
         const ROS_TYPE_NAME: &'static str = "std_msgs/UInt8MultiArray";
         const MD5SUM: &'static str = "82373f1612381bb6ee473b5cd6f5d89c";
-        const DEFINITION: &'static str = r#"# This was originally provided as an example message.
+        const DEFINITION: &'static str = r####"# This was originally provided as an example message.
 # It is deprecated as of Foxy
 # It is recommended to create your own semantically meaningful message.
 # However if you would like to continue using this please use the equivalent in example_msgs.
@@ -7543,7 +7543,7 @@ MSG: std_msgs/MultiArrayDimension
 
 string label   # label of given dimension
 uint32 size    # size of given dimension (in type units)
-uint32 stride  # stride of given dimension"#;
+uint32 stride  # stride of given dimension"####;
     }
 }
 #[allow(unused_imports)]
@@ -7573,7 +7573,7 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for EmptyRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/EmptyRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7589,7 +7589,7 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for EmptyResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/EmptyResponse";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(dead_code)]
     pub struct Empty {}
@@ -7615,7 +7615,8 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for SetBoolRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/SetBoolRequest";
         const MD5SUM: &'static str = "8b94c1b53db61fb6aed406028ad6332a";
-        const DEFINITION: &'static str = r#"bool data # e.g. for hardware enabling / disabling"#;
+        const DEFINITION: &'static str =
+            r####"bool data # e.g. for hardware enabling / disabling"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7634,8 +7635,8 @@ pub mod std_srvs {
     impl ::roslibrust::RosMessageType for SetBoolResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/SetBoolResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"bool success   # indicate successful run of triggered service
-string message # informational, e.g. for error messages"#;
+        const DEFINITION: &'static str = r####"bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages"####;
     }
     #[allow(dead_code)]
     pub struct SetBool {}
@@ -7659,7 +7660,7 @@ string message # informational, e.g. for error messages"#;
     impl ::roslibrust::RosMessageType for TriggerRequest {
         const ROS_TYPE_NAME: &'static str = "std_srvs/TriggerRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7678,8 +7679,8 @@ string message # informational, e.g. for error messages"#;
     impl ::roslibrust::RosMessageType for TriggerResponse {
         const ROS_TYPE_NAME: &'static str = "std_srvs/TriggerResponse";
         const MD5SUM: &'static str = "937c9679a518e3a18d831e57125ea522";
-        const DEFINITION: &'static str = r#"bool success   # indicate successful run of triggered service
-string message # informational, e.g. for error messages"#;
+        const DEFINITION: &'static str = r####"bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages"####;
     }
     #[allow(dead_code)]
     pub struct Trigger {}
@@ -7726,7 +7727,7 @@ pub mod stereo_msgs {
     impl ::roslibrust::RosMessageType for DisparityImage {
         const ROS_TYPE_NAME: &'static str = "stereo_msgs/DisparityImage";
         const MD5SUM: &'static str = "cb0de8feef04280238c7b77d74b2beca";
-        const DEFINITION: &'static str = r#"# Separate header for compatibility with current TimeSynchronizer.
+        const DEFINITION: &'static str = r####"# Separate header for compatibility with current TimeSynchronizer.
 # Likely to be removed in a later release, use image.header instead.
 std_msgs/Header header
 
@@ -7825,7 +7826,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
 }
 #[allow(unused_imports)]
@@ -7868,7 +7869,7 @@ pub mod test_msgs {
     impl ::roslibrust::RosMessageType for Defaults {
         const ROS_TYPE_NAME: &'static str = "test_msgs/Defaults";
         const MD5SUM: &'static str = "43c441dc2b521c313f54affd982b5314";
-        const DEFINITION: &'static str = r#"# This message is specifically for testing generating of default values
+        const DEFINITION: &'static str = r####"# This message is specifically for testing generating of default values
 # Examples based on https://docs.ros.org/en/rolling/Concepts/About-ROS-Interfaces.html
 uint8 x 42
 int16 y -2000
@@ -7883,7 +7884,7 @@ string[] s_vec ["hello", "world"]
 # string[] s_vec_2 ['hello', 'world']
 
 # TODO ROS says this is valid, but we currently don't handle
-#string single_quote 'Jane Doe'"#;
+#string single_quote 'Jane Doe'"####;
     }
 }
 #[allow(unused_imports)]
@@ -7917,7 +7918,7 @@ pub mod trajectory_msgs {
     impl ::roslibrust::RosMessageType for JointTrajectory {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/JointTrajectory";
         const MD5SUM: &'static str = "d63e3b4556d9dbd9f48b5ab4a03f1fee";
-        const DEFINITION: &'static str = r#"# The header is used to specify the coordinate frame and the reference time for
+        const DEFINITION: &'static str = r####"# The header is used to specify the coordinate frame and the reference time for
 # the trajectory durations
 std_msgs/Header header
 
@@ -7966,7 +7967,7 @@ float64[] accelerations
 float64[] effort
 
 # Desired time from the trajectory start to arrive at this trajectory point.
-builtin_interfaces/Duration time_from_start"#;
+builtin_interfaces/Duration time_from_start"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -7988,7 +7989,7 @@ builtin_interfaces/Duration time_from_start"#;
     impl ::roslibrust::RosMessageType for JointTrajectoryPoint {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/JointTrajectoryPoint";
         const MD5SUM: &'static str = "2c812f86aa886c93954e333721749ac5";
-        const DEFINITION: &'static str = r#"# Each trajectory point specifies either positions[, velocities[, accelerations]]
+        const DEFINITION: &'static str = r####"# Each trajectory point specifies either positions[, velocities[, accelerations]]
 # or positions[, effort] for the trajectory to be executed.
 # All specified values are in the same order as the joint names in JointTrajectory.msg.
 
@@ -8013,7 +8014,7 @@ float64[] accelerations
 float64[] effort
 
 # Desired time from the trajectory start to arrive at this trajectory point.
-builtin_interfaces/Duration time_from_start"#;
+builtin_interfaces/Duration time_from_start"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8033,7 +8034,7 @@ builtin_interfaces/Duration time_from_start"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointTrajectory {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/MultiDOFJointTrajectory";
         const MD5SUM: &'static str = "d00d14d97bd70c5eb648278240cfb066";
-        const DEFINITION: &'static str = r#"# The header is used to specify the coordinate frame and the reference time for the trajectory durations
+        const DEFINITION: &'static str = r####"# The header is used to specify the coordinate frame and the reference time for the trajectory durations
 std_msgs/Header header
 
 # A representation of a multi-dof joint trajectory (each point is a transformation)
@@ -8188,7 +8189,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -8209,7 +8210,7 @@ float64 z"#;
     impl ::roslibrust::RosMessageType for MultiDOFJointTrajectoryPoint {
         const ROS_TYPE_NAME: &'static str = "trajectory_msgs/MultiDOFJointTrajectoryPoint";
         const MD5SUM: &'static str = "6731945e53cbc0fbc6e93c28f7416a71";
-        const DEFINITION: &'static str = r#"# Each multi-dof joint can specify a transform (up to 6 DOF).
+        const DEFINITION: &'static str = r####"# Each multi-dof joint can specify a transform (up to 6 DOF).
 geometry_msgs/Transform[] transforms
 
 # There can be a velocity specified for the origin of the joint.
@@ -8280,7 +8281,7 @@ MSG: geometry_msgs/Vector3
 
 float64 x
 float64 y
-float64 z"#;
+float64 z"####;
     }
 }
 #[allow(unused_imports)]
@@ -8324,7 +8325,7 @@ pub mod visualization_msgs {
     impl ::roslibrust::RosMessageType for ImageMarker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/ImageMarker";
         const MD5SUM: &'static str = "829dd5d9ba39b8c3844252ebd8b47b96";
-        const DEFINITION: &'static str = r#"int32 CIRCLE=0
+        const DEFINITION: &'static str = r####"int32 CIRCLE=0
 int32 LINE_STRIP=1
 int32 LINE_LIST=2
 int32 POLYGON=3
@@ -8382,7 +8383,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl ImageMarker {
@@ -8416,7 +8417,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarker";
         const MD5SUM: &'static str = "d71737fa44c5bdefd6bdb4fa9b2b86e5";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 # If header.time is set to 0, the marker will be retransformed into
 # its frame on each timestep. You will receive the pose feedback
 # in the same frame.
@@ -9160,7 +9161,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -9185,7 +9186,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerControl {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerControl";
         const MD5SUM: &'static str = "7b945e790a2d68f430a6eb79f33bf8df";
-        const DEFINITION: &'static str = r#"# Represents a control that is to be displayed together with an interactive marker
+        const DEFINITION: &'static str = r####"# Represents a control that is to be displayed together with an interactive marker
 
 # Identifying string for this control.
 # You need to assign a unique value to this to receive feedback from the GUI
@@ -9553,7 +9554,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerControl {
@@ -9595,7 +9596,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerFeedback {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerFeedback";
         const MD5SUM: &'static str = "880e5141421ed8d30906fad686bc17bd";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 std_msgs/Header header
 
 # Identifying string. Must be unique in the topic namespace.
@@ -9681,7 +9682,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerFeedback {
@@ -9710,7 +9711,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerInit {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerInit";
         const MD5SUM: &'static str = "5d275694a5cb7ea4627f917a9eb1b4cd";
-        const DEFINITION: &'static str = r#"# Identifying string. Must be unique in the topic namespace
+        const DEFINITION: &'static str = r####"# Identifying string. Must be unique in the topic namespace
 # that this server works on.
 string server_id
 
@@ -11189,7 +11190,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11209,7 +11210,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerPose {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerPose";
         const MD5SUM: &'static str = "b88540594a0f8e3fe46c720be41faa03";
-        const DEFINITION: &'static str = r#"# Time/frame info.
+        const DEFINITION: &'static str = r####"# Time/frame info.
 std_msgs/Header header
 
 # Initial pose. Also, defines the pivot point for rotations.
@@ -11262,7 +11263,7 @@ MSG: std_msgs/Header
 builtin_interfaces/Time stamp
 
 # Transform frame with which this data is associated.
-string frame_id"#;
+string frame_id"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -11285,7 +11286,7 @@ string frame_id"#;
     impl ::roslibrust::RosMessageType for InteractiveMarkerUpdate {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/InteractiveMarkerUpdate";
         const MD5SUM: &'static str = "8f52c675c849441ae87da82eaa4d6eb5";
-        const DEFINITION: &'static str = r#"# Identifying string. Must be unique in the topic namespace
+        const DEFINITION: &'static str = r####"# Identifying string. Must be unique in the topic namespace
 # that this server works on.
 string server_id
 
@@ -12837,7 +12838,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(unused)]
     impl InteractiveMarkerUpdate {
@@ -12878,7 +12879,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for Marker {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/Marker";
         const MD5SUM: &'static str = "56c6324983a404ead7a426609371feed";
-        const DEFINITION: &'static str = r#"# See:
+        const DEFINITION: &'static str = r####"# See:
 #  - http://www.ros.org/wiki/rviz/DisplayTypes/Marker
 #  - http://www.ros.org/wiki/rviz/Tutorials/Markers%3A%20Basic%20Shapes
 #
@@ -13062,7 +13063,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(unused)]
     impl Marker {
@@ -13099,7 +13100,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for MarkerArray {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/MarkerArray";
         const MD5SUM: &'static str = "11e38f15427197858cf46456867167bd";
-        const DEFINITION: &'static str = r#"Marker[] markers
+        const DEFINITION: &'static str = r####"Marker[] markers
 ================================================================================
 MSG: geometry_msgs/Point
 # This contains the position of a point in free space
@@ -13391,7 +13392,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13413,7 +13414,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for MenuEntry {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/MenuEntry";
         const MD5SUM: &'static str = "b90ec63024573de83b57aa93eb39be2d";
-        const DEFINITION: &'static str = r#"# MenuEntry message.
+        const DEFINITION: &'static str = r####"# MenuEntry message.
 #
 # Each InteractiveMarker message has an array of MenuEntry messages.
 # A collection of MenuEntries together describe a
@@ -13466,7 +13467,7 @@ string command
 uint8 FEEDBACK=0
 uint8 ROSRUN=1
 uint8 ROSLAUNCH=2
-uint8 command_type"#;
+uint8 command_type"####;
     }
     #[allow(unused)]
     impl MenuEntry {
@@ -13492,14 +13493,14 @@ uint8 command_type"#;
     impl ::roslibrust::RosMessageType for MeshFile {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/MeshFile";
         const MD5SUM: &'static str = "39f264648e441626a1045a7d9ef1ba17";
-        const DEFINITION: &'static str = r#"# Used to send raw mesh files.
+        const DEFINITION: &'static str = r####"# Used to send raw mesh files.
 
 # The filename is used for both debug purposes and to provide a file extension
 # for whatever parser is used.
 string filename
 
 # This stores the raw text of the mesh file.
-uint8[] data"#;
+uint8[] data"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13518,10 +13519,10 @@ uint8[] data"#;
     impl ::roslibrust::RosMessageType for UVCoordinate {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/UVCoordinate";
         const MD5SUM: &'static str = "4f5254e0e12914c461d4b17a0cd07f7f";
-        const DEFINITION: &'static str = r#"# Location of the pixel as a ratio of the width of a 2D texture.
+        const DEFINITION: &'static str = r####"# Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13537,7 +13538,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for GetInteractiveMarkersRequest {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/GetInteractiveMarkersRequest";
         const MD5SUM: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
-        const DEFINITION: &'static str = r#""#;
+        const DEFINITION: &'static str = r####""####;
     }
     #[allow(non_snake_case)]
     #[derive(
@@ -13556,7 +13557,7 @@ float32 v"#;
     impl ::roslibrust::RosMessageType for GetInteractiveMarkersResponse {
         const ROS_TYPE_NAME: &'static str = "visualization_msgs/GetInteractiveMarkersResponse";
         const MD5SUM: &'static str = "923b76ef2c497d4ff5f83a061d424d3b";
-        const DEFINITION: &'static str = r#"# Sequence number.
+        const DEFINITION: &'static str = r####"# Sequence number.
 # Set to the sequence number of the latest update message
 # at the time the server received the request.
 # Clients use this to detect if any updates were missed.
@@ -15029,7 +15030,7 @@ MSG: visualization_msgs/UVCoordinate
 # Location of the pixel as a ratio of the width of a 2D texture.
 # Values should be in range: [0.0-1.0].
 float32 u
-float32 v"#;
+float32 v"####;
     }
     #[allow(dead_code)]
     pub struct GetInteractiveMarkers {}


### PR DESCRIPTION

## Description

Messages like https://github.com/mavlink/mavros/blob/master/mavros_msgs/msg/ADSBVehicle.msg fail to build as described in #229 without this raw string literal change- I've added a copy of it into `ros1_test_msgs/`.

## Fixes
Closes: #229

## Checklist
- [x] Update CHANGELOG.md

