### PR TITLE
Remove unneeded dep on futures::Future from _common

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,10 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "roslibrust_common"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
- "futures",
  "md5",
  "serde",
  "thiserror 2.0.6",

--- a/roslibrust_common/Cargo.toml
+++ b/roslibrust_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roslibrust_common"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = [ "carter <carterjschultz@gmail.com>" ]
 license = "MIT"
@@ -16,5 +16,3 @@ anyhow = "1.0"
 serde = { workspace = true }
 # Used for md5sum calculation
 md5 = "0.7"
-# Used for async trait definitions
-futures = "0.3"


### PR DESCRIPTION
## Description
Just purging a dep that should never has been used, std::future::Future has been in std since 1.36.

## Fixes
Closes: `number`

## Checklist
- [x] Update CHANGELOG.md

