### PR TITLE
Subscribers Now Support futures_core::Stream via .to_stream() + Example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - roslibrust_codegen now support time conversions from chrono::DateTime and chrono::Duration to roslibrust's internal types.
+- Subscribers now have a `.to_stream()` method that converts them to a [futures_core::Stream] for easy integration with async Rust. See [examples/tokio_stream_operations.rs](https://github.com/RosLibRust/roslibrust/blob/master/roslibrust/examples/tokio_stream_operations.rs) for usage.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2640,7 @@ dependencies = [
  "serde",
  "test-log",
  "tokio",
+ "tokio-stream",
  "zenoh",
 ]
 
@@ -2661,6 +2684,8 @@ name = "roslibrust_common"
 version = "0.15.1"
 dependencies = [
  "anyhow",
+ "async-stream",
+ "futures-core",
  "md5",
  "serde",
  "thiserror 2.0.6",
@@ -3650,6 +3675,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/roslibrust/Cargo.toml
+++ b/roslibrust/Cargo.toml
@@ -25,6 +25,8 @@ test-log = { workspace = true }
 abort-on-drop = "0.2"
 log = { workspace = true }
 tokio = { workspace = true }
+# Used in examples
+tokio-stream = "0.1"
 serde = { workspace = true }
 # Used to generate messages for the examples
 roslibrust_codegen = { path = "../roslibrust_codegen" }

--- a/roslibrust/examples/tokio_stream_operations.rs
+++ b/roslibrust/examples/tokio_stream_operations.rs
@@ -1,0 +1,93 @@
+//! This example shows off using tokio's StreamExt to manipulate async streams.
+use roslibrust_common::traits::*;
+use tokio_stream::StreamExt;
+
+roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_interfaces");
+
+async fn example_publisher_task(publisher: impl roslibrust::Publish<std_msgs::Header>) {
+    for seq in 0..50 {
+        publisher
+            .publish(&std_msgs::Header {
+                stamp: std::time::SystemTime::now().try_into().unwrap(),
+                seq,
+                frame_id: "test".to_string(),
+            })
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Sets up a subscriber that could get either of two versions of a message
+/// Note this is currently only supported by the rosbridge backend as this behavior relies on serde_json's fallback capabilities
+#[cfg(feature = "mock")]
+#[tokio::main]
+async fn main() {
+    use log::*;
+    env_logger::init();
+
+    let mock_ros = roslibrust::mock::MockRos::new();
+
+    let publisher = mock_ros
+        .advertise::<std_msgs::Header>("filter_example_talker")
+        .await
+        .unwrap();
+
+    // Spawn a task to publish in the background
+    tokio::spawn(example_publisher_task(publisher));
+
+    // Create a regular subscriber
+    let subscriber = mock_ros
+        .subscribe::<std_msgs::Header>("filter_example_talker")
+        .await
+        .unwrap();
+
+    // Convert the subscriber into a stream
+    let stream = subscriber.into_stream();
+
+    // Use [tokio_stream::StreamExt::map] to convert from Result<T> to T
+    // This can be convienent if you don't care about Lagged, Serialization problems, etc.
+    let stream = stream.map(|msg| match msg {
+        Ok(msg) => msg,
+        Err(e) => {
+            panic!("Failed to get message: {e}");
+        }
+    });
+
+    // Use [tokio_stream::StreamExt::filter] to filter out even seqs, just to demonstrate that filter works
+    let stream = stream.filter(|msg| msg.seq % 2 == 1);
+
+    // Use [tokio_stream::StreamExt::timeout] to apply a timeout
+    let stream = stream.timeout(std::time::Duration::from_secs(1));
+
+    // Streams have to be pinned:
+    // See: https://tokio.rs/tokio/tutorial/streams
+    tokio::pin!(stream);
+
+    // Actually run the stream now
+    loop {
+        let msg = stream.next().await;
+        match msg {
+            Some(Ok(msg)) => {
+                // This will only log odd numbered messages!
+                info!("Got msg: {:?}", msg);
+            }
+            Some(Err(e)) => {
+                // After message #49 is logged this will timeout, log and end the example
+                error!("Timeout!: {e}");
+                break;
+            }
+            None => {
+                // This case will never occur
+                // roslibrust Subscriber streams will always continue to yield values
+                // Even if they backend disconnects, they are expected to try to reconnect and re-establish yielding values when that happens
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "mock"))]
+fn main() {
+    eprintln!("This example does nothing without compiling with the feature 'mock'");
+}

--- a/roslibrust_common/Cargo.toml
+++ b/roslibrust_common/Cargo.toml
@@ -16,3 +16,7 @@ anyhow = "1.0"
 serde = { workspace = true }
 # Used for md5sum calculation
 md5 = "0.7"
+# Required for subscribers to implement into_stream
+futures-core = "0.3"
+# Used for implementation of into_stream for subscribers
+async-stream = "0.3"

--- a/roslibrust_genmsg/src/lib.rs
+++ b/roslibrust_genmsg/src/lib.rs
@@ -189,7 +189,9 @@ impl<'a> CodeGenerator<'a> {
 }
 
 /// Create a code generator for C++ headers.
-pub fn make_cpp_generator<P: AsRef<Path>>(search_paths: &[P]) -> std::io::Result<CodeGenerator> {
+pub fn make_cpp_generator<P: AsRef<Path>>(
+    search_paths: &[P],
+) -> std::io::Result<CodeGenerator<'_>> {
     CodeGeneratorBuilder::new(search_paths, cpp::MESSAGE_HEADER_TMPL)
         .add_type_mapping(ROS_TYPE_TO_CPP_TYPE_MAP.clone())
         .service_template(cpp::SERVICE_HEADER_TMPL)


### PR DESCRIPTION
## Description
Futures stream support.

## Fixes
Closes: #240

## Checklist
- [x] Update CHANGELOG.md

