### PR TITLE
Solve complex lifetime issue with ServiceFn

### DIFF
--- a/.github/workflows/noetic.yml
+++ b/.github/workflows/noetic.yml
@@ -30,14 +30,7 @@ jobs:
         run: source /root/.cargo/env; rustc --version
       - name: Lint
         run: source /root/.cargo/env; cargo fmt --all -- --check
-      - name: Build Main Lib
-        run: source /root/.cargo/env; cargo build
-        # This step is required to confirm feature combinations work, the main workspace build does all features
-      - name: Build Proc Macro
-        run: source /root/.cargo/env; cargo build -p roslibrust_codegen_macro
-      - name: Unit Tests
-        run: source /root/.cargo/env; RUST_LOG=debug cargo test
       - name: Start rosbridge
         run: source /opt/ros/noetic/setup.bash; roslaunch rosbridge_server rosbridge_websocket.launch & disown; rosrun rosapi rosapi_node & sleep 1
-      - name: Integration Tests
+      - name: Build and Test
         run: source /opt/ros/noetic/setup.bash; source /root/.cargo/env; RUST_LOG=debug cargo test --features ros1_test,all -- --test-threads 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The return type of service functions has been changed from "Box<dyn std::error::Error + Send + Sync + 'static>" to `roslibrust::ServiceError`.
+Which is an alias for `anyhow::Error`. This should make it easier to return errors from service functions, and deals with some tricky lifetime issues around holding ServiceServers
+
 ## 0.15.0 - June 20th, 2025
 
 ### Added

--- a/roslibrust/examples/generic_client_services.rs
+++ b/roslibrust/examples/generic_client_services.rs
@@ -29,7 +29,7 @@ async fn main() {
     impl<T: Ros> MyNode<T> {
         fn handle_service(
             _request: std_srvs::SetBoolRequest,
-        ) -> Result<std_srvs::SetBoolResponse, Box<dyn std::error::Error + Send + Sync>> {
+        ) -> Result<std_srvs::SetBoolResponse, roslibrust::ServiceError> {
             // Not actually doing anything here just example
             // Note: if we did want to set a bool, we'd probably want to use Arc<Mutex<bool>>
             Ok(std_srvs::SetBoolResponse {

--- a/roslibrust/examples/rosbridge_service_server.rs
+++ b/roslibrust/examples/rosbridge_service_server.rs
@@ -8,7 +8,7 @@ roslibrust_codegen_macro::find_and_generate_ros_messages!("assets/ros1_common_in
 fn my_service(
     request: std_srvs::SetBoolRequest,
     my_string: &str,
-) -> Result<std_srvs::SetBoolResponse, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<std_srvs::SetBoolResponse, roslibrust::ServiceError> {
     log::info!("Got request to set bool: {request:?}");
     log::info!("Using my string: {}", my_string); // Use the string here
 
@@ -55,10 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _handle = client
         .advertise_service::<std_srvs::SetBool, _>(
             "/my_set_bool",
-            move |request: std_srvs::SetBoolRequest| -> Result<
-                std_srvs::SetBoolResponse,
-                Box<dyn std::error::Error + Send + Sync>,
-            > { my_service(request, my_string) },
+            move |request: std_srvs::SetBoolRequest| my_service(request, my_string),
         )
         .await?;
 

--- a/roslibrust/tests/ros1_native_integration_tests.rs
+++ b/roslibrust/tests/ros1_native_integration_tests.rs
@@ -395,15 +395,9 @@ mod tests {
             .await
             .unwrap();
 
-        let server_fn = |request: test_msgs::AddTwoIntsRequest| -> Result<
-            test_msgs::AddTwoIntsResponse,
-            Box<dyn std::error::Error + Send + Sync>,
-        > {
+        let server_fn = |request| {
             info!("Got request: {request:?}");
-            return Err(Box::new(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "test message",
-            )));
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "test message").into());
         };
 
         // Create the server

--- a/roslibrust_rosbridge/src/integration_tests.rs
+++ b/roslibrust_rosbridge/src/integration_tests.rs
@@ -224,13 +224,12 @@ mod integration_tests {
         let opt = ClientHandleOptions::new(LOCAL_WS).timeout(TIMEOUT);
         let client = ClientHandle::new_with_options(opt).await?;
 
-        let cb =
-            |_req: SetBoolRequest| -> Result<SetBoolResponse, Box<dyn std::error::Error + Send + Sync>> {
-                Ok(SetBoolResponse {
-                    success: true,
-                    message: "call_success".to_string(),
-                })
-            };
+        let cb = |_req: SetBoolRequest| {
+            Ok(SetBoolResponse {
+                success: true,
+                message: "call_success".to_string(),
+            })
+        };
 
         let topic = "/self_service_call";
 

--- a/roslibrust_test/Cargo.toml
+++ b/roslibrust_test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 env_logger = "0.10"
-roslibrust = { path = "../roslibrust", features = ["ros1", "codegen", "macro"] }
+roslibrust = { path = "../roslibrust", features = ["ros1", "codegen", "macro", "mock"] }
 lazy_static = "1.4"
 tokio = { workspace = true }
 log = { workspace = true }

--- a/roslibrust_test/tests/mock_node_is_send.rs
+++ b/roslibrust_test/tests/mock_node_is_send.rs
@@ -1,0 +1,91 @@
+//! Test covers a specific problem we tripped over
+//!
+//! A moderately complex "node" that held various roslibrust types would end up
+//! not being compatible with tokio::spawn.
+
+use roslibrust::traits::*;
+use roslibrust_test::ros1::*;
+
+// Very basic node that holds a bunch of ros types generically
+struct Node<T: Ros> {
+    ros: T,
+    publisher: T::Publisher<std_msgs::String>,
+    subscriber: T::Subscriber<std_msgs::String>,
+    service: T::ServiceServer,
+    client: T::ServiceClient<std_srvs::SetBool>,
+}
+
+impl<T: Ros> Node<T> {
+    // Basic node impl that constructs the types
+    async fn new(ros: T) -> Self {
+        let publisher = ros
+            .advertise::<std_msgs::String>("test_topic")
+            .await
+            .unwrap();
+        let subscriber = ros
+            .subscribe::<std_msgs::String>("test_topic")
+            .await
+            .unwrap();
+        let service = ros
+            .advertise_service::<std_srvs::SetBool, _>("test_service", |_| {
+                Ok(std_srvs::SetBoolResponse {
+                    success: true,
+                    message: "You set my bool!".to_string(),
+                })
+            })
+            .await
+            .unwrap();
+        let client = ros
+            .service_client::<std_srvs::SetBool>("test_service")
+            .await
+            .unwrap();
+        Self {
+            ros,
+            publisher,
+            subscriber,
+            service,
+            client,
+        }
+    }
+
+    // Very basic usage of the node types to verify they are tokio compatible
+    async fn run(mut self) {
+        self.publisher
+            .publish(&std_msgs::String {
+                data: "Hello, world!".to_string(),
+            })
+            .await
+            .unwrap();
+        self.client
+            .call(&std_srvs::SetBoolRequest { data: true })
+            .await
+            .unwrap();
+        let msg = self.subscriber.next().await.unwrap();
+        assert_eq!(msg.data, "Hello, world!");
+    }
+}
+
+async fn test_node(ros: roslibrust::mock::MockRos) {
+    let node = Node::new(ros).await;
+    node.run().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mock_node_is_send() {
+    let ros = roslibrust::mock::MockRos::new();
+    // This previously would fail to compile with:
+    /*
+       error[E0308]: mismatched types
+      --> roslibrust_test/tests/mock_node_is_send.rs:73:5
+       |
+    73 |     tokio::spawn(test_node(ros)).await.unwrap();
+       |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+       |
+       = note: expected enum `Result<_, Box<dyn StdError + Send + Sync>>`
+                  found enum `Result<_, Box<(dyn StdError + Send + Sync + 'static)>>`
+       */
+    // This was fixed by switching the error type of our ServiceFn trait to use 'anyhow::Error'
+    // Which solved some very nasty lifetime inference issues.
+    // This test simply compiling is enough to really test it
+    tokio::spawn(test_node(ros));
+}


### PR DESCRIPTION
## Description
Changes ServiceFn error type to anyhow::Error. This was the only effective way I found to work around significant lifetime issues where Rust would get confused about whether a given closure/future was Box<dyn Error + Send + Sync> or Box<dyn Error + Send + Sync + 'static>.

## Fixes
Closes: #262

## Checklist
- [x] Update CHANGELOG.md

