### PR TITLE
Expose subscribe_any and verify its behavior with unit test + documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ROS1 backend now exposes `subscribe_any` to allow subscribing to any topic and receiving raw bytes instead of a deserialized message.
+
 ### Fixed
 
 - MockRos ServiceClients now work correctly if created before the service server is advertised.

--- a/roslibrust_ros1/src/lib.rs
+++ b/roslibrust_ros1/src/lib.rs
@@ -52,6 +52,7 @@ mod service_client;
 pub use service_client::ServiceClient;
 mod subscriber;
 pub use subscriber::Subscriber;
+pub use subscriber::SubscriberAny;
 mod service_server;
 pub use service_server::ServiceServer;
 mod tcpros;

--- a/roslibrust_ros1/src/node/handle.rs
+++ b/roslibrust_ros1/src/node/handle.rs
@@ -108,6 +108,15 @@ impl NodeHandle {
         Ok(Publisher::new(topic_name, sender, shutdown))
     }
 
+    /// Subscribe to a topic as a raw byte stream with no automatic deserialization.
+    ///
+    /// This will return the raw bytes of the message as received over the wire, not including the 4 byte overall length header.
+    ///
+    /// For publishing a string message "hello", the returned bytes would be:
+    ///       [0x05, 0x00, 0x00, 0x00, // field length = 5
+    ///        0x68, 0x65, 0x6c, 0x6c, 0x6f] // "hello"
+    ///
+    /// See: [https://wiki.ros.org/ROS/TCPROS] for more information on the wire format.
     pub async fn subscribe_any(
         &self,
         topic_name: &str,
@@ -120,6 +129,12 @@ impl NodeHandle {
         Ok(SubscriberAny::new(receiver))
     }
 
+    /// Subscribe to a topic with automatic deserialization to the given type.
+    ///
+    /// This function will return an error if the rosmaster cannot be contacted.
+    ///
+    /// This function may be called multiple times on the same topic and each subscriber will receive a unique copy of the message.
+    /// This function may be called multiple times on the same topic with different message types, deserialization will be attempted individually for them.
     pub async fn subscribe<T: roslibrust_common::RosMessageType>(
         &self,
         topic_name: &str,

--- a/roslibrust_ros1/src/subscriber.rs
+++ b/roslibrust_ros1/src/subscriber.rs
@@ -69,7 +69,10 @@ impl SubscriberAny {
         }
     }
 
-    // pub async fn next(&mut self) -> Option<Result<ShapeShifter, SubscriberError>> {
+    /// Gets the next message from the subscriber.
+    /// Uniquely for SubscriberAny, this returns the raw bytes of the message.
+    /// Note: over the wire ros messages include a 4 byte length header before the message body.
+    /// This function does not return that header, merely the message body.
     pub async fn next(&mut self) -> Option<Result<Vec<u8>, SubscriberError>> {
         let data = match self.receiver.recv().await {
             Ok(v) => v,

--- a/roslibrust_ros1/tests/ros1_subcriber_publisher_any.rs
+++ b/roslibrust_ros1/tests/ros1_subcriber_publisher_any.rs
@@ -1,0 +1,72 @@
+//! Integration test for PublisherAny and SubscriberAny round-trip communication
+
+#[cfg(feature = "ros1_test")]
+mod tests {
+    use roslibrust_ros1::NodeHandle;
+    use tokio::time::timeout;
+
+    /// Test round-trip publish and subscribe using PublisherAny and SubscriberAny
+    /// This test verifies that:
+    /// 1. A PublisherAny can publish raw bytes to a topic
+    /// 2. A SubscriberAny can receive those raw bytes from the same topic
+    /// 3. The received bytes match the published bytes exactly
+    #[test_log::test(tokio::test)]
+    async fn test_publisher_any_subscriber_any_roundtrip() {
+        // Create a node handle
+        let nh = NodeHandle::new(
+            "http://localhost:11311",
+            "test_publisher_any_subscriber_any",
+        )
+        .await
+        .expect("Failed to create node handle");
+
+        // Create a PublisherAny for std_msgs/String
+        let publisher = nh
+            .advertise_any(
+                "/test_roundtrip",
+                "std_msgs/String",
+                "string data\n",
+                1,
+                true,
+            )
+            .await
+            .expect("Failed to create publisher");
+
+        // Create a SubscriberAny for the same topic
+        let mut subscriber = nh
+            .subscribe_any("/test_roundtrip", 1)
+            .await
+            .expect("Failed to create subscriber");
+
+        // Prepare test data: serialized std_msgs/String with data="hello"
+        // Note: API doesn't consider the overall message length header as part of message
+        // Overall length header will be added automatically
+        // Format: [field_length (4 bytes), data (5 bytes)]
+        let test_message: Vec<u8> = vec![
+            0x05, 0x00, 0x00, 0x00, // field length = 5
+            0x68, 0x65, 0x6c, 0x6c, 0x6f, // "hello"
+        ];
+
+        // Publish the message
+        publisher
+            .publish(&test_message)
+            .await
+            .expect("Failed to publish message");
+
+        // Subscribe and receive the message with a timeout
+        let receive_result =
+            timeout(std::time::Duration::from_millis(500), subscriber.next()).await;
+
+        // Verify we received the message
+        let received_message = receive_result
+            .expect("Timeout waiting for message")
+            .expect("Subscriber returned None")
+            .expect("Failed to receive message");
+
+        // Verify the received bytes match the published bytes
+        assert_eq!(
+            received_message, test_message,
+            "Received message does not match published message"
+        );
+    }
+}


### PR DESCRIPTION
## Description
`subscribe_any` is ready for prime time.

## Fixes
Closes: #272 

## Checklist
- [x] Update CHANGELOG.md

