### PR TITLE
[ROS2-Zenoh] in ZenohClient::new, pass in a ZContext

### DIFF
--- a/roslibrust_ros2/examples/service_server.rs
+++ b/roslibrust_ros2/examples/service_server.rs
@@ -1,16 +1,19 @@
 use log::*;
 use roslibrust_common::traits::*;
+// Required to get .build() method on ZContextBuilder
+use ros_z::Builder;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
 
-    let ctx = ZContextBuilder::default()
+    let ctx = ros_z::context::ZContextBuilder::default()
         .with_domain_id(0)
         .with_connect_endpoints(["tcp/[::]:7447"])
-        .build()?;
+        .build()
+        .unwrap();
 
-    let client = roslibrust_ros2::ZenohClient::new(ctx, "test_service_server_callable_node")
+    let client = roslibrust_ros2::ZenohClient::new(&ctx, "test_service_server_callable_node")
         .await
         .unwrap();
 

--- a/roslibrust_ros2/src/lib.rs
+++ b/roslibrust_ros2/src/lib.rs
@@ -310,18 +310,24 @@ mod tests {
     #[cfg(feature = "ros2_zenoh_test")]
     mod integration_tests {
         use crate::ZenohClient;
+        use ros_z::context::ZContext;
         use roslibrust_common::traits::*;
 
-        fn make_test_context() -> _ {
+        fn make_test_context() -> ZContext {
+            use ros_z::context::ZContextBuilder;
+            use ros_z::Builder;
+
             ZContextBuilder::default()
                 .with_domain_id(0)
                 .with_connect_endpoints(["tcp/[::]:7447"])
-                .build()?
+                .build()
+                .unwrap()
         }
 
         #[tokio::test(flavor = "multi_thread")]
         async fn test_subscribe_basic() {
-            let client = ZenohClient::new(make_test_context(), "test_subscribe_basic_node")
+            let ctx = make_test_context();
+            let client = ZenohClient::new(&ctx, "test_subscribe_basic_node")
                 .await
                 .unwrap();
             let mut subscriber = client
@@ -354,7 +360,8 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread")]
         async fn test_pubsub_basic() {
-            let client = ZenohClient::new(make_test_context(), "test_publish_basic_node")
+            let ctx = make_test_context();
+            let client = ZenohClient::new(&ctx, "test_publish_basic_node")
                 .await
                 .unwrap();
 
@@ -386,7 +393,8 @@ mod tests {
         #[ignore]
         #[tokio::test(flavor = "multi_thread")]
         async fn test_service_server_callable() {
-            let client = ZenohClient::new(make_test_context(), "test_service_server_callable_node")
+            let ctx = make_test_context();
+            let client = ZenohClient::new(&ctx, "test_service_server_callable_node")
                 .await
                 .unwrap();
 
@@ -435,8 +443,8 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread")]
         async fn test_service_zenoh_to_zenoh() {
-            // Create service server
-            let node = ZenohClient::new(make_test_context(), "test_service_server_zenoh")
+            let ctx = make_test_context();
+            let node = ZenohClient::new(&ctx, "test_service_server_zenoh")
                 .await
                 .unwrap();
 


### PR DESCRIPTION
This is not necessarily the solution, but I wanted to start a discussion.

I'm very interested in using roslibrust to connect to an existing ros2/zenoh system. I haven't tested if this even works at all, because the remote system uses ROS2 default with rmw_zenoh, not ros-z specifically.

Nevertheless, unless I'm missing something, the current implementation of ``ZenohClient`` looks very limited. It uses ``ZContextBuilder::default()`` with hardcoded ``domain=0`` and ``connect=localhost:7447``, so I can't even connect to a remote system.

I believe the only real solution is to let the user configure the context, and pass it in as a parameter, similar to how ros1 ``ZenohClient`` takes a ``zenoh::Session`` as parameter.