### PR TITLE
Cleanup ros1 Subscriber subscription on drop

### DIFF
--- a/roslibrust_ros1/src/node/actor.rs
+++ b/roslibrust_ros1/src/node/actor.rs
@@ -810,10 +810,13 @@ impl Node {
             return Ok(());
         }
         let _ = self.subscriptions.remove(topic);
-        self.client.unregister_subscriber(topic).await.map_err(|e| {
-            log::error!("Failed to unregister subscriber with master for {topic}: {e:?}");
-            NodeError::IoError(io::Error::from(io::ErrorKind::ConnectionAborted))
-        })?;
+        self.client
+            .unregister_subscriber(topic)
+            .await
+            .map_err(|e| {
+                log::error!("Failed to unregister subscriber with master for {topic}: {e:?}");
+                NodeError::IoError(io::Error::from(io::ErrorKind::ConnectionAborted))
+            })?;
         debug!("Removed subscription and unregistered with master: {topic}");
         Ok(())
     }

--- a/roslibrust_ros1/src/node/actor.rs
+++ b/roslibrust_ros1/src/node/actor.rs
@@ -89,6 +89,10 @@ pub enum NodeMsg {
         reply: oneshot::Sender<Result<(), String>>,
         topic: String,
     },
+    UnregisterSubscriber {
+        reply: oneshot::Sender<Result<(), String>>,
+        topic: String,
+    },
 }
 
 /// Represents a communication handle to an underlying node server
@@ -309,6 +313,21 @@ impl NodeServerHandle {
         received.map_err(|err| {
             log::error!("Failed to register service server: {err}");
             NodeError::IoError(io::Error::from(io::ErrorKind::ConnectionAborted))
+        })
+    }
+
+    /// Asks the node actor to tear down a subscription if no live `Subscriber`s remain.
+    /// Called from `Subscriber::drop` via `NodeHandle::unsubscribe`.
+    pub(crate) async fn unregister_subscriber(&self, topic: &str) -> Result<(), NodeError> {
+        let (tx, rx) = oneshot::channel();
+        self.node_server_sender
+            .send(NodeMsg::UnregisterSubscriber {
+                reply: tx,
+                topic: topic.to_string(),
+            })?;
+        rx.await?.map_err(|e| {
+            log::error!("Failed to unregister subscriber {topic:?}: {e:?}");
+            NodeError::IoError(io::Error::from(io::ErrorKind::InvalidData))
         })
     }
 
@@ -557,6 +576,13 @@ impl Node {
                         .map_err(|err| err.to_string()),
                 );
             }
+            NodeMsg::UnregisterSubscriber { reply, topic } => {
+                let _ = reply.send(
+                    self.unregister_subscriber(&topic)
+                        .await
+                        .map_err(|err| err.to_string()),
+                );
+            }
             NodeMsg::RegisterSubscriber {
                 reply,
                 topic,
@@ -767,6 +793,28 @@ impl Node {
                 std::io::ErrorKind::AddrInUse,
             )));
         }
+        Ok(())
+    }
+
+    /// Tear down a subscription if no live `Subscriber<T>` / `SubscriberAny` for the topic
+    /// remain. Called when a `Subscriber` is dropped.
+    /// Dropping the `Subscription` aborts its per-publisher TCP reader tasks via the
+    /// `Vec<ChildTask<()>>` it owns.
+    async fn unregister_subscriber(&mut self, topic: &str) -> Result<(), NodeError> {
+        let Some(subscription) = self.subscriptions.get(topic) else {
+            // Already removed (e.g. by node shutdown). Not an error.
+            return Ok(());
+        };
+        if subscription.subscriber_count() != 0 {
+            // Other live Subscribers exist — keep the subscription.
+            return Ok(());
+        }
+        let _ = self.subscriptions.remove(topic);
+        self.client.unregister_subscriber(topic).await.map_err(|e| {
+            log::error!("Failed to unregister subscriber with master for {topic}: {e:?}");
+            NodeError::IoError(io::Error::from(io::ErrorKind::ConnectionAborted))
+        })?;
+        debug!("Removed subscription and unregistered with master: {topic}");
         Ok(())
     }
 

--- a/roslibrust_ros1/src/node/handle.rs
+++ b/roslibrust_ros1/src/node/handle.rs
@@ -126,7 +126,11 @@ impl NodeHandle {
             .inner
             .register_subscriber::<roslibrust_common::ShapeShifter>(topic_name, queue_size)
             .await?;
-        Ok(SubscriberAny::new(receiver))
+        Ok(SubscriberAny::new(
+            receiver,
+            topic_name.to_string(),
+            self.weak_clone(),
+        ))
     }
 
     /// Subscribe to a topic with automatic deserialization to the given type.
@@ -144,7 +148,11 @@ impl NodeHandle {
             .inner
             .register_subscriber::<T>(topic_name, queue_size)
             .await?;
-        Ok(Subscriber::new(receiver))
+        Ok(Subscriber::new(
+            receiver,
+            topic_name.to_string(),
+            self.weak_clone(),
+        ))
     }
 
     pub async fn service_client<T: roslibrust_common::RosServiceType>(
@@ -174,6 +182,20 @@ impl NodeHandle {
             .await?;
         // Super important. Don't clone self or we create a STRONG NodeHandle that keeps the node alive
         Ok(ServiceServer::new(service_name, self.weak_clone()))
+    }
+
+    /// Not intended to be called manually.
+    /// Automatically called when the last `Subscriber` / `SubscriberAny` for a topic is dropped.
+    /// Spawns a task to ask the node actor to tear down the subscription if no live
+    /// subscribers remain.
+    pub(crate) fn unsubscribe(&self, topic_name: &str) {
+        let copy = self.clone();
+        let name_copy = topic_name.to_string();
+        tokio::spawn(async move {
+            if let Err(e) = copy.inner.unregister_subscriber(&name_copy).await {
+                log::error!("Failed to unregister subscriber for {name_copy:?}: {e:?}");
+            }
+        });
     }
 
     // TODO Major: This should probably be moved to NodeServerHandle?

--- a/roslibrust_ros1/src/subscriber.rs
+++ b/roslibrust_ros1/src/subscriber.rs
@@ -1,4 +1,4 @@
-use crate::{names::Name, tcpros::ConnectionHeader};
+use crate::{names::Name, tcpros::ConnectionHeader, NodeHandle};
 use abort_on_drop::ChildTask;
 use bytes::Bytes;
 use log::*;
@@ -17,15 +17,23 @@ use tokio_util::sync::CancellationToken;
 use super::tcpros;
 
 pub struct Subscriber<T> {
-    // Uses Bytes for efficient cloning (reference counted) when there are multiple subscribers
+    // Uses Bytes for efficient cloning (reference counted) when there are multiple subscribers.
     receiver: broadcast::Receiver<Bytes>,
+    topic_name: String,
+    node_handle: NodeHandle,
     _phantom: PhantomData<T>,
 }
 
 impl<T: RosMessageType> Subscriber<T> {
-    pub(crate) fn new(receiver: broadcast::Receiver<Bytes>) -> Self {
+    pub(crate) fn new(
+        receiver: broadcast::Receiver<Bytes>,
+        topic_name: String,
+        node_handle: NodeHandle,
+    ) -> Self {
         Self {
             receiver,
+            topic_name,
+            node_handle,
             _phantom: PhantomData,
         }
     }
@@ -60,15 +68,23 @@ impl<T: RosMessageType> Subscriber<T> {
 }
 
 pub struct SubscriberAny {
-    // Uses Bytes for efficient cloning (reference counted) when there are multiple subscribers
+    // Uses Bytes for efficient cloning (reference counted) when there are multiple subscribers.
     receiver: broadcast::Receiver<Bytes>,
+    topic_name: String,
+    node_handle: NodeHandle,
     _phantom: PhantomData<ShapeShifter>,
 }
 
 impl SubscriberAny {
-    pub(crate) fn new(receiver: broadcast::Receiver<Bytes>) -> Self {
+    pub(crate) fn new(
+        receiver: broadcast::Receiver<Bytes>,
+        topic_name: String,
+        node_handle: NodeHandle,
+    ) -> Self {
         Self {
             receiver,
+            topic_name,
+            node_handle,
             _phantom: PhantomData,
         }
     }
@@ -85,6 +101,29 @@ impl SubscriberAny {
             Err(RecvError::Lagged(n)) => return Some(Err(SubscriberError::Lagged(n))),
         };
         Some(Ok(data))
+    }
+}
+
+// Release our broadcast::Receiver BEFORE signalling the node actor so its
+// `Subscription::subscriber_count()` check sees an accurate `receiver_count()`.
+// We can't move out of `&mut self` in `Drop`, so swap in a fresh detached
+// receiver (which is dropped at end of scope) — its capacity is irrelevant.
+fn drop_receiver(slot: &mut broadcast::Receiver<Bytes>) {
+    let (_tx, dummy) = broadcast::channel(1);
+    let _ = std::mem::replace(slot, dummy);
+}
+
+impl<T> Drop for Subscriber<T> {
+    fn drop(&mut self) {
+        drop_receiver(&mut self.receiver);
+        self.node_handle.unsubscribe(&self.topic_name);
+    }
+}
+
+impl Drop for SubscriberAny {
+    fn drop(&mut self) {
+        drop_receiver(&mut self.receiver);
+        self.node_handle.unsubscribe(&self.topic_name);
     }
 }
 
@@ -156,6 +195,14 @@ impl Subscription {
 
     pub fn get_receiver(&self) -> broadcast::Receiver<Bytes> {
         self.msg_sender.subscribe()
+    }
+
+    /// Number of live external `Subscriber<T>` / `SubscriberAny` instances holding a receiver
+    /// for this subscription. The `Subscription` keeps one internal receiver (`_msg_receiver`)
+    /// to keep the broadcast channel alive even when there are momentarily no external
+    /// subscribers; that one is subtracted out here.
+    pub(crate) fn subscriber_count(&self) -> usize {
+        self.msg_sender.receiver_count().saturating_sub(1)
     }
 
     pub async fn add_publisher_source(

--- a/roslibrust_ros1/tests/ros1_subscriber_reconnection.rs
+++ b/roslibrust_ros1/tests/ros1_subscriber_reconnection.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "ros1_test")]
 mod tests {
     use roslibrust_common::RosMessageType;
+    use roslibrust_ros1::NodeHandle;
     use roslibrust_test::ros1::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -303,5 +304,51 @@ mod tests {
         }
 
         mock_pub.cleanup().await;
+    }
+
+    /// Test that dropping a subscriber automatically unregisters the subscription
+    /// This verifies that the automatic unsubscribing mechanism works correctly
+    #[test_log::test(tokio::test)]
+    async fn verify_automatic_unsubscribe() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    {
+        const TOPIC: &str = "/test_auto_unsub";
+        const NODE_NAME: &str = "/verify_automatic_unsubscribe";
+
+        let node = NodeHandle::new("http://localhost:11311", NODE_NAME).await?;
+        log::info!("Created node handle");
+
+        // Create a MasterClient to query rosmaster state
+        let master_client = roslibrust_ros1::MasterClient::new(
+            "http://localhost:11311",
+            "http://localhost:0", // We don't need a real URI for queries
+            "/test_master_client",
+        )
+        .await?;
+
+        // Initially, the node should not be subscribed to the topic
+        let state = master_client.get_system_state().await?;
+        assert!(!state.is_subscribed(TOPIC, NODE_NAME));
+        log::info!("Confirmed no initial subscription");
+
+        // Create a subscriber in a scope so we can drop it
+        {
+            let _subscriber = node.subscribe::<std_msgs::String>(TOPIC, 1).await?;
+            log::info!("Created subscriber");
+
+            // Verify the subscription is now registered with rosmaster
+            let state = master_client.get_system_state().await?;
+            assert!(state.is_subscribed(TOPIC, NODE_NAME));
+            log::info!("Confirmed subscription registered with rosmaster");
+        } // Subscriber is dropped here
+
+        // Give the async unsubscribe task time to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Verify the subscription has been automatically removed from rosmaster
+        let state = master_client.get_system_state().await?;
+        assert!(!state.is_subscribed(TOPIC, NODE_NAME));
+        log::info!("Confirmed automatic unsubscribe completed");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description
Subscriber `Drop` impl now unregisters the subscription with master and the publishing node if it's the last subscriber alive. Based on the discussion from 2024 in #200, possibly there might be a better method preferred now. Manual testing shows that it works as expected without leaking resources.

Disclosure: Code changes are Claude-assisted :robot: but manually reviewed and tested.


## Fixes
Closes: #200 

## Checklist
- [ ] Update CHANGELOG.md

